### PR TITLE
EZP-27289: Configure Travis and SauceLabs to test with supported browsers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,26 @@
 dist: trusty
 language: node_js
+
 before_script:
-    - npm install -g bower
-    - bower install
+  - npm install -g bower
+  - bower install
+
 addons:
-    firefox: latest
-    apt:
-        sources:
-            - google-chrome
-        packages:
-            - google-chrome-stable
-script:
-    - xvfb-run npm test
-    - npm run lint
-branches:
-    only:
-        - master
+  firefox: latest
+  apt:
+    sources:
+      - google-chrome
+    packages:
+      - google-chrome-stable
+
+script: $TEST_CMD
+
+matrix:
+  include:
+    - env: TEST_CMD="xvfb-run npm run test-local"
+    - env: TEST_CMD="npm run test-sauce"
+
+env:
+  global:
+    - secure: bOOUU+HSfghZEH4npV/suJaML+yTwxruMO2z/ZtELrMSTzDD3RJXbeyEcpS54Hq5PdyjumPT+zm2qG10TgMjsbNPNTkt+6X00ksWbpqmhwoiDxsXJRpOTjPUm5EtRjXAmo+jpIIEb3APWbXtjWrD9O2gmObkYuMLbEVJiKulOgg2dsNEc4ri2lFYGt6WHKZq3A1YHzr2AED57mMhwTrmZOXB422Jq/CLnUnygqEvOmjTIyVEAqStyRczqBjSe7WAV5yZFFd5v40ZzVoC66MevI7g81I/iIMEb+HIh+2QJCzo1gQH0WpqtEHuNoCiznBMkAfpNY2JzW0Ac1eWZ+942ZE34MY0xogmHugwGVa0y3N/GRMwpKLKa5PPSj0cIQqDfMXInaa36dfHOsc4hDzh7IdQRFDM5aMOklOWh15x7CGMbJmuQHmponaAMOghLId23T4ADr0beleYK27kMF6rC6c0f6k7m0CNoDqiXKptY7KcOOwN4xTmznEVAcpbVGiDpU1/KBa53AwWC2Smgeg52Yeg9Vw+qY2UVgfBEJg8JIFYlPBgnrpOHbI1unpvJdG9Ol1F5H+CA6W3RbxFXU2NF5UihbwrnCotGlqE3GQynKilJTsJu5xNaf7n4mNkbb3n/2HVWimGzZscX08glw/JhsPDrxLTW+YPzw9S/yWzo0A=
+    - secure: HhBc714MaABVM11RfdPgo4Ov8eqNGiQfe7Ivu4t0KMg+2d04Dn95bMLCKzX1LHwlVYrslrXODHhgRptT7tJBYyFes0pF+4R9zYtH4BN6e5VQkJz+MmF5Z00C4OkDImrNQEHKxGOFyCLyBWzppoEngiz6aS2W7BCMI0/RU/jpppHQTQ1GV9lQVW4XzcFy2hJxQF13vIw6Rx14dgtfiwKW0dAJp3nG9ccEMVh4pwlNgHPARV7mKkRVkw+fhxXNr9NcubCksXTLBlOmCKTGz9mSenyFyQ+gTLy/57ZY5zH3TLMK4tMCr5KzQVI77Oi70WvxXMXH/y2bYdM2TMHp21lxDT5bD1TtsTXiab7lsedQ3gOiK4Aujio/igkUrSxYCu2qWhQQ5Cpl2m1eD5D5NYDuvyNPYrydyTrNPLUnJ1vOqMpo9xyt2999QDAbT33Q0G33wkKRzloVSO2Y1owjUjSGvfewI6Mmibp3IW5asqPxRpTyLP4dwnWew30Kvx4qO6DFyTyTMoZm3P/ImX3iat0mIu9Rj3668FeD8MyvfT3H6cQmaJPzjRWlrOrIy6IFHKZgFNs/xblbXGHmFnWEaonpXNBLCPaj8BUTa7rwv685t1fmtM/OK2NLlfs5R4vF1Hd/Pvb7YNHUGHkslF/HwexY5VcTstyC1l5QqWcvRnCNnnA=

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ script: $TEST_CMD
 
 matrix:
   include:
+    - env: TEST_CMD="npm run lint"
     - env: TEST_CMD="xvfb-run npm run test-local"
     - env: TEST_CMD="npm run test-sauce"
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,8 @@ matrix:
   include:
     - env: TEST_CMD="xvfb-run npm run test-local"
     - env: TEST_CMD="npm run test-sauce"
+  allow_failures:
+    - env: TEST_CMD="npm run test-sauce"
 
 env:
   global:

--- a/README.md
+++ b/README.md
@@ -58,3 +58,20 @@ platforms/browsers are defined in `wct.conf.json`.
 ```bash
 $ npm run lint
 ```
+
+### Run local demo of components
+
+```bash
+$ npm run serve
+```
+
+This will run a local web server to serve the demo. After running that command,
+it should display the URL to reach the demo.
+
+Alternatively, you can execute:
+
+```bash
+$ npm run serve -- -o
+```
+
+to open the index page in the default browser.

--- a/README.md
+++ b/README.md
@@ -14,13 +14,37 @@ Provides the following custom elements used in the Hybrid Platform UI:
 * Node >= 6.x ([nvm](https://github.com/creationix/nvm)
 is an easy way to get it running)
 * `bower` should be installed globally with `npm install -g bower`
+* before any of the following tasks, make sure the bower and npm dependencies are
+  installed and up to date by running
+  ```bash
+  $ npm install
+  $ bower install
+  ```
 
-### Run unit test
+### Run unit tests
+
+#### Using local browsers
 
 ```bash
-$ bower install # needed only once
-$ npm test
+$ npm run test-local
 ```
+
+This will executes unit tests in local browsers.
+
+#### Using SauceLabs
+
+First, create an account at https://saucelabs.com/ (It's free for Open Source
+projects).
+Then run the following commands:
+
+```bash
+$ export SAUCE_USERNAME="your_sauce_labs_username"
+$ export SAUCE_ACCESS_KEY="your_sauce_labs_key"
+$ npm run test-sauce
+```
+
+The unit tests should be run using the Sauce Labs infrastructure. Targeted
+platforms/browsers are defined in `wct.conf.json`.
 
 ### Run code style checks
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,13 @@ $ npm run test-local
 
 This will executes unit tests in local browsers.
 
+To keep the test browsers open (and keep the test web server alive), you can add
+the `-p` option:
+
+```bash
+$ npm run test-local -- -p
+```
+
 #### Using SauceLabs
 
 First, create an account at https://saucelabs.com/ (It's free for Open Source

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "test": "npm run test-local",
     "test-local": "./node_modules/.bin/polymer test --skip-plugin sauce",
     "test-sauce": "./node_modules/.bin/polymer test --skip-plugin local",
+    "serve": "./node_modules/.bin/polymer serve",
     "lint": "./node_modules/.bin/eslint js test/js"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "web-component-tester": "^5.0.1"
   },
   "scripts": {
-    "test": "./node_modules/.bin/polymer test",
+    "test": "npm run test-local",
+    "test-local": "./node_modules/.bin/polymer test --skip-plugin sauce",
+    "test-sauce": "./node_modules/.bin/polymer test --skip-plugin local",
     "lint": "./node_modules/.bin/eslint js test/js"
   },
   "repository": {

--- a/wct.conf.json
+++ b/wct.conf.json
@@ -1,3 +1,32 @@
 {
-    "suites": ["test/*.html"]
+    "suites": ["test/*.html"],
+    "plugins": {
+        "sauce": {
+            "browsers": [{
+                "browserName": "MicrosoftEdge",
+                "platform": "Windows 10",
+                "version": "14.14393"
+            }, {
+                "browserName": "safari",
+                "platform": "macOS 10.12",
+                "version": "10.0"
+            }, {
+                "browserName": "firefox",
+                "platform": "macOS 10.12",
+                "version": "52.0"
+            }, {
+                "browserName": "firefox",
+                "platform": "Windows 10",
+                "version": "52.0"
+            }, {
+                "browserName": "chrome",
+                "platform": "macOS 10.12",
+                "version": "57.0"
+            }, {
+                "browserName": "chrome",
+                "platform": "Windows 10",
+                "version": "57.0"
+            }]
+        }
+    }
 }


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-27289

# Description

This patch configures `wct` (Web Component Tester) and Travis-CI to also run unit tests with [SauceLabs](https://saucelabs.com/) to test in a wider set of browsers. With this patch tests are run using:

* Stable Chrome on Linux (directly on Travis)
* Stable Firefox on Linux (directly on Travis)
* Firefox 52 on Windows 10 (with SauceLabs)
* Firefox 52 on MacOS 10.12 (with SauceLabs)
* Chrome 57 on Windows 10 (with SauceLabs)
* Chrome 57 on MacOS 10.12 (with SauceLabs)
* Edge 14 on Windows 10 (with SauceLabs)
* Safari 10.0 on MacOS 10.12 (with SauceLabs)

As mentioned in #2, this is currently failing with Edge and Safari. ~~And unfortunately, because of https://github.com/travis-ci/travis-ci/issues/7663, we can not use `allow_failures` in .travis.yml, so builds will fail until we fix that (very soon hopefully)~~ I misunderstood how `allow_failures` is supposed to work, this is fixed now.