### PR TITLE
EZP-27351: Integrate Hybrid Platform UI packages

### DIFF
--- a/demo/update1.json
+++ b/demo/update1.json
@@ -10,6 +10,9 @@
                 "update": {
                     "attributes": {
                         "data-last-update": "update 1"
+                    },
+                    "properties": {
+                        "innerHTML": "Navigation updated with a <i>property update</i>"
                     }
                 }
             },

--- a/demo/update2.json
+++ b/demo/update2.json
@@ -10,6 +10,9 @@
                 "update": {
                     "attributes": {
                         "data-last-update": "update 2"
+                    },
+                    "properties": {
+                        "innerHTML": "Navigation, updated again :)"
                     }
                 }
             },

--- a/js/ez-platform-ui-app.js
+++ b/js/ez-platform-ui-app.js
@@ -20,11 +20,15 @@
 
             element = element.parentNode.replaceChild(doc.body.firstChild, element);
         } else if ( updateStruct ) {
+            const properties = updateStruct.properties || {};
             const attributes = updateStruct.attributes || {};
             const children = updateStruct.children || [];
 
             Object.keys(attributes).forEach(function (attributeName) {
                 element.setAttribute(attributeName, attributes[attributeName]);
+            });
+            Object.keys(properties).forEach(function (propertyName) {
+                element[propertyName] = properties[propertyName];
             });
             children.forEach(function (childUpdate) {
                 if ( childUpdate ) {

--- a/test/js/ez-platform-ui-app.js
+++ b/test/js/ez-platform-ui-app.js
@@ -4,8 +4,10 @@ describe('ez-platform-ui-app', function() {
     const urlEmptyUpdate = '/test/responses/empty.json';
     const urlBaseUpdate = '/test/responses/set-data-updated-attr.json';
     const urlSetAttributes = '/test/responses/set-attributes.json';
+    const urlSetProperties = '/test/responses/set-properties.json';
     const urlStringUpdate = '/test/responses/string-update.json';
     const urlSetChildAttributes = '/test/responses/set-child-attributes.json';
+    const urlSetChildProperties = '/test/responses/set-child-properties.json';
     const urlFalsyChildUpdate = '/test/responses/falsy-child-update.json';
     const urlWrong = '/test/responses/wrong-selector.json';
 
@@ -320,6 +322,25 @@ describe('ez-platform-ui-app', function() {
             element.url = urlSetAttributes;
         });
 
+        it('should be able to set properties', function (done) {
+            element.addEventListener('ez:app:updated', function () {
+                assert.equal(
+                    'updated title',
+                    element.title,
+                    'The `title` property should have been set'
+                );
+                assert.equal(
+                    'updated lang',
+                    element.lang,
+                    'The `lang` property should have been set'
+                );
+
+                done();
+            });
+            element.url = urlSetProperties;
+        });
+
+
         it('should be able to apply a string update to a child', function (done) {
             element.addEventListener('ez:app:updated', function () {
                 assert.equal(
@@ -348,6 +369,25 @@ describe('ez-platform-ui-app', function() {
                 done();
             });
             element.url = urlSetChildAttributes;
+        });
+
+        it('should be able to set properties on a child', function (done) {
+            element.addEventListener('ez:app:updated', function () {
+                const updated = element.querySelector('nav');
+
+                assert.equal(
+                    'updated content',
+                    updated.innerHTML,
+                    'The `innerHTML` property should have been updated'
+                );
+                assert.equal(
+                    'updated title',
+                    updated.title,
+                    'The `title` property should have been updated'
+                );
+                done();
+            });
+            element.url = urlSetChildProperties;
         });
 
         it('should handle a falsy child update', function (done) {

--- a/test/responses/set-child-properties.json
+++ b/test/responses/set-child-properties.json
@@ -1,0 +1,14 @@
+{
+    "selector": "ez-platform-ui-app",
+    "update": {
+        "children": [{
+            "selector": "nav",
+            "update": {
+                "properties": {
+                    "innerHTML": "updated content",
+                    "title": "updated title"
+                }
+            }
+        }]
+    }
+}

--- a/test/responses/set-data-updated-prop.json
+++ b/test/responses/set-data-updated-prop.json
@@ -1,0 +1,8 @@
+{
+    "selector": "ez-platform-ui-app",
+    "update": {
+        "properties": {
+            "className": "updated"
+        }
+    }
+}

--- a/test/responses/set-properties.json
+++ b/test/responses/set-properties.json
@@ -1,0 +1,9 @@
+{
+    "selector": "ez-platform-ui-app",
+    "update": {
+        "properties": {
+            "title": "updated title",
+            "lang": "updated lang"
+        }
+    }
+}


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-27351

# Description

This patch brings the ability to set properties (as opposed to attributes) on element. Attributes and properties are complementary. Attributes works well on standard HTML element but are restricted to string value. Properties can receive any type of value and depending on the element implementation might have various effects like being reflected in the markup as an attribute.

In the current code base, the ability to set a property will be used to set the `visible` property (and attribute) of `<ez-toolbar>`.

# Tests

unit tests and manual test in static demo (hybrid-platform-ui is not ready yet use that feature, see https://jira.ez.no/browse/EZP-27322)