### PR TITLE
EZP-27361: Add form handling to ez-platform-ui-app

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -59,10 +59,7 @@
             "property"
         ],
         "dot-notation": [
-            "error",
-            {
-                "allowKeywords": false
-            }
+            "error"
         ],
         "eol-last": "off",
         "eqeqeq": "off",

--- a/bower.json
+++ b/bower.json
@@ -2,16 +2,13 @@
   "name": "hybrid-platform-ui-core-components",
   "main": "core-components.html",
   "dependencies": {
-    "polymer": "Polymer/polymer#^2.0.0-rc.2"
+    "polymer": "^2.0.0"
   },
   "devDependencies": {
-    "iron-demo-helpers": "PolymerElements/iron-demo-helpers#2.0-preview",
-    "web-component-tester": "^6.0.0-prerelease.5",
-    "webcomponentsjs": "webcomponents/webcomponentsjs#^1.0.0-rc.5",
+    "iron-demo-helpers": "^2.0.0",
+    "web-component-tester": "^6.0.0",
+    "webcomponentsjs": "^1.0.0",
     "element-matches": "jonathantneal/closest#^2.0.1",
     "fetch": "^2.0.3"
-  },
-  "resolutions": {
-    "polymer": "^2.0.0-rc.2"
   }
 }

--- a/demo/ez-platform-ui-app.html
+++ b/demo/ez-platform-ui-app.html
@@ -42,8 +42,16 @@
                     Navigation
                 </nav>
                 <main>
+                    <h4>Simple link</h4>
                     <p>default main content</p>
                     <p><a href="update1.json">Update 1</a></p>
+
+                    <hr>
+                    <h4>Form (only GET, polyserve does not support POST)</h4>
+                    <form action="update1.json" method="get">
+                        <input type="hidden" name="hidden" value="I'm hidden">
+                        <button name="apply">Apply the update 1</button>
+                    </form>
                 </main>
             </ez-platform-ui-app>
         </template>

--- a/js/ez-platform-ui-app.js
+++ b/js/ez-platform-ui-app.js
@@ -36,7 +36,39 @@
      * `<ez-platform-ui-app>` represents the application in a page which will
      * enhance the navigation by avoiding full page refresh. It is responsible
      * for handling click on links and form submit and for fetching and applying
-     * the corresponding update.
+     * the corresponding update. It also manipulates the browser's history so
+     * that the back and forward buttons works as expected. A large part of this
+     * mechanism relies on the server ability to render the page as a JSON
+     * update struct and that's why it's possible opt out from it.
+     *
+     * If a link has the class `ez-js-standard-navigation` or if it has an
+     * ancestor having that class, the app will just let the navigation happen.
+     * (or let another JavaScript code to handle click on such link)
+     *
+     * Example:
+     * ```
+     * <ul class="ez-js-standard-navigation">
+     *   <li><a href="/">This link won't be enhanced</a></li>
+     *   <li><a href="/path">Same for this one</a>
+     * </ul>
+     * <a href="/path2" class="ez-js-standard-navigation">Or this one</a>
+     * ```
+     *
+     * For forms, the class `ez-js-standard-form` set on a form or on an
+     * ancestor of a form allows the form to be submitted normally (or let
+     * another JavaScript code to handle form submit).
+     *
+     * Example:
+     * ```
+     * <form action="/whatever" class="ez-js-standard-form">
+     *   <input type="text" name="something" value="the app ignores me!">
+     * </form>
+     * <div class="ez-js-standard-form">
+     *   <form action="/whatever">
+     *     <input type="text" name="name" value="the app ignores me as well!">
+     *   </form>
+     * </div>
+     * ```
      *
      * Among others standard APIs, this component relies on `fetch` and
      * `Element.closest`. `fetch` is not supported by Safari 10.0 and

--- a/js/ez-platform-ui-app.js
+++ b/js/ez-platform-ui-app.js
@@ -265,7 +265,7 @@
             this.addEventListener('click', (e) => {
                 const anchor = e.target.closest('a');
 
-                if ( PlatformUiApp._isNavigationLink(anchor) ) {
+                if ( PlatformUiApp._isEnhancedNavigationLink(anchor) ) {
                     e.preventDefault();
                     this.url = anchor.href;
                 } else if ( PlatformUiApp._isSubmitButton(e.target) && PlatformUiApp._isInsideEnhancedForm(e.target) ) {
@@ -319,10 +319,14 @@
          * @static
          * @return {Boolean}
          */
-        static _isNavigationLink(anchor) {
+        static _isEnhancedNavigationLink(anchor) {
             // FIXME: we should probably further check the URI (same origin ?)
-            // we should also allow to opt out from that with a class
-            return anchor && anchor.href && anchor.getAttribute('href').indexOf('#') !== 0;
+            return (
+                anchor &&
+                anchor.href &&
+                anchor.getAttribute('href').indexOf('#') !== 0 &&
+                !anchor.matches('.ez-js-standard-navigation, .ez-js-standard-navigation a')
+            );
         }
 
         /**

--- a/js/ez-platform-ui-app.js
+++ b/js/ez-platform-ui-app.js
@@ -35,8 +35,8 @@
     /**
      * `<ez-platform-ui-app>` represents the application in a page which will
      * enhance the navigation by avoiding full page refresh. It is responsible
-     * for handling click on links and for fetching and applying the
-     * corresponding update.
+     * for handling click on links and form submit and for fetching and applying
+     * the corresponding update.
      *
      * Among others standard APIs, this component relies on `fetch` and
      * `Element.closest`. `fetch` is not supported by Safari 10.0 and
@@ -268,17 +268,16 @@
                 if ( PlatformUiApp._isNavigationLink(anchor) ) {
                     e.preventDefault();
                     this.url = anchor.href;
-                } else if ( PlatformUiApp._isSubmitButton(e.target) ) {
+                } else if ( PlatformUiApp._isSubmitButton(e.target) && PlatformUiApp._isInsideEnhancedForm(e.target) ) {
                     this._formButton = e.target;
                 }
             });
             this.addEventListener('submit', (e) => {
                 const form = e.target;
 
-                // FIXME:
-                // like the navigation, it should be possible to opt out from
-                // that "enhanced" behaviour for instance by setting a class on
-                // the form itself or one of its ancestors.
+                if ( !PlatformUiApp._isInsideEnhancedForm(form) ) {
+                    return;
+                }
                 e.preventDefault();
                 if ( form.method === 'get' ) {
                     // submitting a GET form is like browsing
@@ -335,6 +334,22 @@
          */
         static _isSubmitButton(element) {
             return element && element.matches('form input[type="submit"], form button, form input[type="image"]');
+        }
+
+        /**
+         * Checks whether the given `element` is inside (or is) a form that is
+         * supposed to be enhanced (ie submitted by AJAX). To not be enhanced
+         * the form or one of its ancestor must have the `ez-js-standard-form`
+         * class.
+         *
+         * @param {HTMLElement} element
+         * @static
+         * @return {Boolean}
+         */
+        static _isInsideEnhancedForm(element) {
+            const form = element.closest('form');
+
+            return !form || !form.matches('.ez-js-standard-form, .ez-js-standard-form form');
         }
 
         /**

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
   },
   "devDependencies": {
     "eslint": "^3.19.0",
-    "polymer-cli": "^0.18.0",
-    "web-component-tester": "^5.0.1"
+    "polymer-cli": "^1.0.0",
+    "web-component-tester": "^6.0.0"
   },
   "scripts": {
     "test": "npm run test-local",

--- a/test/ez-platform-ui-app.html
+++ b/test/ez-platform-ui-app.html
@@ -29,6 +29,12 @@
                             </span>
                         </a>
                     </p>
+                    <form action="/test/responses/set-data-updated-attr.json" method="post">
+                        <input type="text" name="text" value="value">
+                        <button name="button" value="button">Button</button>
+                        <input type="submit" value="submit">
+                        <input type="image" value="image">
+                    </form>
                     <main>to be string updated</main>
                     <nav>to be receive an attribute update</nav>
                 </ez-platform-ui-app>

--- a/test/ez-platform-ui-app.html
+++ b/test/ez-platform-ui-app.html
@@ -56,6 +56,14 @@
                         </select>
                         <input type="text" name="simple" value="simple">
                     </form>
+                    <div class="ez-js-standard-form">
+                        <form action="/" method="get">
+                            <input type="text" value="no AJAX" name="no-ajax">
+                        </form>
+                    </div>
+                    <form action="/" method="get" class="ez-js-standard-form">
+                        <input type="text" value="no AJAX" name="no-ajax">
+                    </form>
                     <main>to be string updated</main>
                     <nav>to be receive an attribute update</nav>
                 </ez-platform-ui-app>

--- a/test/ez-platform-ui-app.html
+++ b/test/ez-platform-ui-app.html
@@ -28,6 +28,10 @@
                                 <span class="deep-inside-link">Inside</span>
                             </span>
                         </a>
+                        <a class="ez-js-standard-navigation" href="/test/responses/set-data-updated-attr.json">No AJAX</a>
+                    </p>
+                    <p class="ez-js-standard-navigation">
+                        <a href="/test/responses/set-data-updated-attr.json">No AJAX</a>
                     </p>
                     <form action="/test/responses/set-data-updated-attr.json" method="post">
                         <input type="text" name="text" value="value">

--- a/test/ez-platform-ui-app.html
+++ b/test/ez-platform-ui-app.html
@@ -35,6 +35,27 @@
                         <input type="submit" value="submit">
                         <input type="image" value="image">
                     </form>
+                    <form action="/test/responses/set-data-updated-attr.json" method="get">
+                        <button name="submit">Go</button>
+                        <input type="reset" name="reset">
+                        <input type="submit" value="ignored" name="submit">
+                        <input type="radio" value="not checked" name="radio-not-checked">
+                        <input type="radio" value="radio" name="radio" checked>
+                        <input type="checkbox" name="not-checked" value="not checked">
+                        <input type="checkbox" name="checked" value="checked" checked>
+                        <input type="checkbox" name="checked-no-value" checked>
+                        <select name="select-nothing"></select>
+                        <select name="select-one">
+                            <option value="option" selected>Selected</option>
+                            <option value="not-selected">Not selected</option>
+                        </select>
+                        <select name="select-multiple">
+                            <option value="option1" selected>Selected</option>
+                            <option value="option2" selected>Selected</option>
+                            <option value="option3">Not selected</option>
+                        </select>
+                        <input type="text" name="simple" value="simple">
+                    </form>
                     <main>to be string updated</main>
                     <nav>to be receive an attribute update</nav>
                 </ez-platform-ui-app>

--- a/test/js/ez-platform-ui-app.js
+++ b/test/js/ez-platform-ui-app.js
@@ -195,6 +195,10 @@ describe('ez-platform-ui-app', function() {
             );
         }
 
+        function prevent(e) {
+            e.preventDefault();
+        }
+
         describe('navigation', function () {
             it('should handle click on regular link', function () {
                 const link = element.querySelector('.enhanced-link');
@@ -243,6 +247,42 @@ describe('ez-platform-ui-app', function() {
 
                 assertEventIgnored(event, element, initialUrl);
             });
+
+            describe('opt out', function () {
+                beforeEach(function () {
+                    document.addEventListener('click', prevent);
+                });
+
+                afterEach(function () {
+                    document.removeEventListener('click', prevent);
+                });
+
+                function testIgnoredLink(selector) {
+                    const link = element.querySelector(selector);
+
+                    element.addEventListener('click', function (e) {
+                        assert.isFalse(
+                            e.defaultPrevented,
+                            'The click event should not be prevented'
+                        );
+                    });
+                    simulateClick(link);
+
+                    assert.notEqual(
+                        link.href,
+                        element.url,
+                        'The app should not navigate the link url'
+                    );
+                }
+
+                it('should ignore click on links having the ez-js-standard-navigation class', function () {
+                    testIgnoredLink('a.ez-js-standard-navigation');
+                });
+
+                it('should ignore click on links having an ancestor with the ez-js-standard-navigation class', function () {
+                    testIgnoredLink('.ez-js-standard-navigation a');
+                });
+            });
         });
 
         describe('form', function () {
@@ -265,10 +305,6 @@ describe('ez-platform-ui-app', function() {
             });
 
             describe('opt out', function () {
-                function prevent(e) {
-                    e.preventDefault();
-                }
-
                 beforeEach(function () {
                     document.addEventListener('submit', prevent);
                 });


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-27361

# Description

This patch brings form support to Hybrid Platform UI application. Like when navigating, forms are now submitted with an AJAX request unless the form or one of its ancestor has the class `ez-js-standard-form`. While at it, I also add the same opt out mechanism for links with the `ez-js-standard-navigation`.

For the edit priority form in subitem to work, https://github.com/ezsystems/PlatformUIBundle/pull/865 is required.

Screencast:

[![](https://img.youtube.com/vi/NZ-ZHK6H_eA/0.jpg)](http://www.youtube.com/watch?v=NZ-ZHK6H_eA "Click to play on Youtube.com")


* [x] Submit form (POST) in AJAX
* [x] Handle GET forms
* [x] Update static demo
* [x] Fix Subitem list edit priority form to not be enhanced by the app

# Tests

manual and unit tests