### PR TITLE
EZP-27375: Upgraded to Polymer 2.0 and last stable release of associated packages

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,16 +2,13 @@
   "name": "hybrid-platform-ui-core-components",
   "main": "core-components.html",
   "dependencies": {
-    "polymer": "Polymer/polymer#^2.0.0-rc.2"
+    "polymer": "^2.0.0"
   },
   "devDependencies": {
-    "iron-demo-helpers": "PolymerElements/iron-demo-helpers#2.0-preview",
-    "web-component-tester": "^6.0.0-prerelease.5",
-    "webcomponentsjs": "webcomponents/webcomponentsjs#^1.0.0-rc.5",
+    "iron-demo-helpers": "^2.0.0",
+    "web-component-tester": "^6.0.0",
+    "webcomponentsjs": "^1.0.0",
     "element-matches": "jonathantneal/closest#^2.0.1",
     "fetch": "^2.0.3"
-  },
-  "resolutions": {
-    "polymer": "^2.0.0-rc.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
   },
   "devDependencies": {
     "eslint": "^3.19.0",
-    "polymer-cli": "^0.18.0",
-    "web-component-tester": "^5.0.1"
+    "polymer-cli": "^1.0.0",
+    "web-component-tester": "^6.0.0"
   },
   "scripts": {
     "test": "npm run test-local",


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-27375
Related to:
* https://github.com/ezsystems/hybrid-platform-ui-assets/pull/2
* https://github.com/ezsystems/PlatformUIBundle/pull/866

# Description

Just upgrade meta files to fetch Polymer 2.0 and related stable associated packages.
A part of the story was also to look at how components can be documented since the Polymer doc elements were not ready during the RC phase. Unfortunately, doc elements are still not ready, so this is postponed to https://jira.ez.no/browse/EZP-27391

# Test

manual and unit test