### PR TITLE
EZP-27356: Rename title app property to pageTitle

### DIFF
--- a/demo/ez-platform-ui-app.html
+++ b/demo/ez-platform-ui-app.html
@@ -24,7 +24,7 @@
             position: absolute;
             right: 0;
             bottom: -2em;
-            content: "title: '" attr(title) "' url: '" attr(url) "'";
+            content: "url: '" attr(url) "'";
         }
         nav:after {
             font-style: italic;

--- a/demo/update1.json
+++ b/demo/update1.json
@@ -1,8 +1,8 @@
 {
     "selector": "ez-platform-ui-app",
     "update": {
-        "attributes": {
-            "title": "Update 1 with update1.json"
+        "properties": {
+            "pageTitle": "Update 1 with update1.json"
         },
         "children": [
             {

--- a/demo/update2.json
+++ b/demo/update2.json
@@ -1,8 +1,8 @@
 {
     "selector": "ez-platform-ui-app",
     "update": {
-        "attributes": {
-            "title": "Update 2 with update2.json"
+        "properties": {
+            "pageTitle": "Update 1 with update1.json"
         },
         "children": [
             {

--- a/js/ez-platform-ui-app.js
+++ b/js/ez-platform-ui-app.js
@@ -100,9 +100,8 @@
                  * Title of the app page. It is the page title by default and
                  * changes are reflected to the page title as well.
                  */
-                title: {
+                pageTitle: {
                     type: String,
-                    reflectToAttribute: true,
                     value: document.title,
                     observer: '_setPageTitle',
                 },
@@ -127,7 +126,7 @@
         }
 
         /**
-         * Sets the page title. It's an observer of the `title` property.
+         * Sets the page title. It's an observer of the `pageTitle` property.
          *
          * @param {String} newValue
          */
@@ -264,7 +263,7 @@
         _pushHistory() {
             history.pushState(
                 {url: this.url, enhanced: true},
-                this.title,
+                this.pageTitle,
                 this.url
             );
         }
@@ -275,7 +274,7 @@
         _replaceHistory() {
             history.replaceState(
                 {url: this.url, enhanced: true},
-                this.title,
+                this.pageTitle,
                 this.url
             );
         }

--- a/test/js/ez-platform-ui-app.js
+++ b/test/js/ez-platform-ui-app.js
@@ -24,11 +24,11 @@ describe('ez-platform-ui-app', function() {
     });
 
     describe('properties', function () {
-        describe('`title`', function () {
+        describe('`pageTitle`', function () {
             it('should default to the document title', function () {
                 assert.equal(
                     document.title,
-                    element.title
+                    element.pageTitle
                 );
             });
 
@@ -36,20 +36,10 @@ describe('ez-platform-ui-app', function() {
                 it('should update the document title', function () {
                     const newTitle = 'Silverchair - Cicada';
 
-                    element.title = newTitle;
+                    element.pageTitle = newTitle;
                     assert.equal(
                         newTitle,
                         document.title
-                    );
-                });
-
-                it('should be reflected to an attribute', function () {
-                    const newTitle = 'Silverchair - Freak';
-
-                    element.title = newTitle;
-                    assert.equal(
-                        newTitle,
-                        element.getAttribute('title')
                     );
                 });
             });
@@ -670,7 +660,7 @@ describe('ez-platform-ui-app', function() {
             element.addEventListener('ez:app:updated', function () {
                 assert.equal(
                     'updated title',
-                    element.title,
+                    element.pageTitle,
                     'The `title` property should have been set'
                 );
                 assert.equal(
@@ -726,7 +716,7 @@ describe('ez-platform-ui-app', function() {
                 );
                 assert.equal(
                     'updated title',
-                    updated.title,
+                    updated.pageTitle,
                     'The `title` property should have been updated'
                 );
                 done();

--- a/test/responses/set-child-properties.json
+++ b/test/responses/set-child-properties.json
@@ -6,7 +6,7 @@
             "update": {
                 "properties": {
                     "innerHTML": "updated content",
-                    "title": "updated title"
+                    "pageTitle": "updated title"
                 }
             }
         }]

--- a/test/responses/set-properties.json
+++ b/test/responses/set-properties.json
@@ -2,7 +2,7 @@
     "selector": "ez-platform-ui-app",
     "update": {
         "properties": {
-            "title": "updated title",
+            "pageTitle": "updated title",
             "lang": "updated lang"
         }
     }


### PR DESCRIPTION
jira: https://jira.ez.no/browse/EZP-27356

## Description 

Renaming title app's property to pageTitle. This is done to avoid confusion between the property of the app and the html title attribute.
Furthermore, now pageTitle app's property isn't reflected as an attribute anymore.

App component stuct updated in https://github.com/ezsystems/hybrid-platform-ui/pull/7