### PR TITLE
Fixed navigation hub to wait for DOM distribution to change it

### DIFF
--- a/ez-navigation-hub.html
+++ b/ez-navigation-hub.html
@@ -1,4 +1,5 @@
 <link rel="import" href="../polymer/polymer-element.html">
+<link rel="import" href="../polymer/lib/utils/render-status.html">
 
 <style>
     ez-navigation-hub {

--- a/js/ez-navigation-hub.js
+++ b/js/ez-navigation-hub.js
@@ -60,6 +60,20 @@
                     this.activeZone = e.target.parentNode.getAttribute('data-zone-identifier');
                 }
             });
+            Polymer.RenderStatus.afterNextRender(this, function () {
+                this._updateActiveZone(this.activeZone, undefined);
+                this._highlightLink(this.matchedLinkUrl, undefined);
+            });
+        }
+
+        /**
+         * Checks whether the element has child elements. This is useful to
+         * check if the DOM has been distributed before applying changes.
+         *
+         * @return {Boolean}
+         */
+        _hasContent() {
+            return this.childElementCount;
         }
 
         /**
@@ -70,6 +84,9 @@
          * @param {String} oldValue
          */
         _updateActiveZone(newValue, oldValue) {
+            if ( !this._hasContent() ) {
+                return;
+            }
             this._highlightZone(oldValue, newValue);
             this._updateNavigation(oldValue, newValue);
         }
@@ -149,6 +166,9 @@
          * @param {String} oldUrl
          */
         _highlightLink(newUrl, oldUrl) {
+            if ( !this._hasContent() ) {
+                return;
+            }
             if ( oldUrl ) {
                 this._getItemByUrl(oldUrl).classList.remove(this.matchedLinkClass);
             }

--- a/test/ez-navigation-hub.html
+++ b/test/ez-navigation-hub.html
@@ -36,6 +36,11 @@
                 </ez-navigation-hub>
             </template>
         </test-fixture>
+        <test-fixture id="EmptyElement">
+            <template>
+                <ez-navigation-hub></ez-navigation-hub>
+            </template>
+        </test-fixture>
         <script src="js/ez-navigation-hub.js"></script>
     </body>
 </html>

--- a/test/js/ez-navigation-hub.js
+++ b/test/js/ez-navigation-hub.js
@@ -69,6 +69,8 @@ describe('ez-navigation-hub', function() {
     });
 
     describe('active zone update', function () {
+        let emptyElement;
+
         function simulateClick(element) {
             const click = new CustomEvent('click', {
                 bubbles: true,
@@ -84,6 +86,14 @@ describe('ez-navigation-hub', function() {
                 'The event should have been prevented'
             );
         }
+
+        beforeEach(function () {
+            emptyElement = fixture('EmptyElement');
+        });
+
+        it('should handle an empty navigation hub', function () {
+            emptyElement.activeZone = 'whatever';
+        });
 
         describe('highlight zone', function () {
             it('should highlight the selected zone', function () {
@@ -132,6 +142,16 @@ describe('ez-navigation-hub', function() {
     });
 
     describe('match link url', function () {
+        let emptyElement;
+
+        beforeEach(function () {
+            emptyElement = fixture('EmptyElement');
+        });
+
+        it('should handle an empty navigation hub', function () {
+            emptyElement.matchedLinkUrl = 'whatever';
+        });
+
         it('should highlight the selected link', function () {
             element.matchedLinkUrl = 'url1';
             assert.isOk(element.querySelector('[href="url1"]').parentNode.classList.contains(element.matchedLinkClass), 'link1 should be highlighted');


### PR DESCRIPTION
# Description

Without this patch, the navigation is broken if we navigate directly to a page in a zone (ie any page besides the Dashboard).

# Tests

unit tests + manual test

