### PR TITLE
EZP-27450: Added ez-tabs mixin

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,24 @@ Provides the following custom elements used in the Hybrid Platform UI:
 * `<ez-navigation-hub>`
 * `<ez-toolbar>`
 
+In addition, this package provides a class expression mixin to add support for
+tabs based on a specific markup. To use that expression mixin, you can write
+something like:
+
+```html
+<link rel="import" href="path/to/polymer/polymer-element.html">
+<link rel="import" href="path/to/hybrid-platform-ui-core-components/mixins/ez-tabs.html">
+
+<script>
+    class MyComponent extends eZ.TabsMixin(Polymer.Element) {
+        // your code
+    }
+</script>
+```
+
+With that, the tabs markup will be automatically recognized. ez-tabs.html also
+provides the base CSS code so that the tabs visually behave as tabs.
+
 ## Developers tasks
 
 **System requirements:**

--- a/README.md
+++ b/README.md
@@ -18,13 +18,36 @@ something like:
 
 <script>
     class MyComponent extends eZ.TabsMixin(Polymer.Element) {
+        static get is() {
+            return 'my-component';
+        }
         // your code
     }
+
+    window.customElements.define(MyComponent.is, MyComponent);
 </script>
 ```
 
 With that, the tabs markup will be automatically recognized. ez-tabs.html also
-provides the base CSS code so that the tabs visually behave as tabs.
+provides the base CSS code so that the tabs visually behave as tabs. So with the
+following code:
+
+```html
+<my-component>
+  <div class="ez-tabs">
+     <ul class="ez-tabs-list">
+       <li class="ez-tabs-label is-tab-selected"><a href="#tab1">Tab 1</a></li>
+       <li class="ez-tabs-label"><a href="#tab2">Tab 2</a></li>
+     </ul>
+     <div class="ez-tabs-panels">
+       <div class="ez-tabs-panel is-tab-selected" id="tab1">Some content</div>
+       <div class="ez-tabs-panel" id="tab2">Some other content</div>
+     </div>
+  </div>
+</my-component>
+```
+
+You should see 2 tabs and should be able to switch from one to the other.
 
 ## Developers tasks
 

--- a/mixins/ez-tabs.html
+++ b/mixins/ez-tabs.html
@@ -1,0 +1,28 @@
+<style>
+.ez-tabs .ez-tabs-list {
+    padding: 0;
+    margin: 0;
+}
+
+.ez-tabs .ez-tabs-label {
+    display: inline-block;
+    padding: 0;
+}
+
+.ez-tabs .ez-tabs-label a {
+    display: block;
+}
+
+.ez-tabs .ez-tabs-label.is-tab-selected a:hover {
+    cursor: default;
+}
+
+.ez-tabs .ez-tabs-panel {
+    display: none;
+}
+
+.ez-tabs .ez-tabs-panel.is-tab-selected {
+    display: block;
+}
+</style>
+<script src="js/ez-tabs.js"></script>

--- a/mixins/js/ez-tabs.js
+++ b/mixins/js/ez-tabs.js
@@ -15,6 +15,11 @@ window.eZ = window.eZ || {};
      *   <div class="ez-tabs-panel" id="tab2">Some other content</div>
      * </div>
      *
+     * Among others standard APIs, this component relies on `Element.closest`.
+     * `Element.closest` is not available in Edge 14. So for this component to
+     * work in this browser, the page should include a polyfill for this
+     * standard API.
+     *
      * @param {Function} superClass
      * @return {Function}
      */

--- a/mixins/js/ez-tabs.js
+++ b/mixins/js/ez-tabs.js
@@ -1,0 +1,71 @@
+window.eZ = window.eZ || {};
+
+(function (ns) {
+    /**
+     * Mixins tabs support into a class extending `superClass`. The resulting
+     * class expects the following HTML markup for tabs to work and to be styled
+     * correctly:
+     *
+     * <ul class="ez-tabs-list">
+     *   <li class="ez-tabs-label is-tab-selected"><a href="#tab1">Tab 1</a></li>
+     *   <li class="ez-tabs-label"><a href="#tab2">Tab 2</a></li>
+     * </ul>
+     * <div class="ez-tabs-panels">
+     *   <div class="ez-tabs-panel is-tab-selected" id="tab1">Some content</div>
+     *   <div class="ez-tabs-panel" id="tab2">Some other content</div>
+     * </div>
+     *
+     * @param {Function} superClass
+     * @return {Function}
+     */
+    ns.TabsMixin = function (superClass) {
+        const TAB_IS_SELECTED = 'is-tab-selected';
+
+        return class extends superClass {
+            connectedCallback() {
+                super.connectedCallback();
+                this._setupTabs();
+            }
+
+            /**
+             * Sets up the tabs so that a user can switch from one tab to
+             * another by clicking on tabs label.
+             */
+            _setupTabs() {
+                this.addEventListener('click', (e) => {
+                    const label = e.target.closest('.ez-tabs-label');
+
+                    if ( label ) {
+                        e.preventDefault();
+                        this._changeTab(e.target.getAttribute('href'), label);
+                    }
+                });
+            }
+
+            /**
+             * Changes tab so that the tab panel corresponding to `panelSelector`
+             * becomes visible and `tabsLabel` element is visually selected.
+             *
+             * @param {String} panelSelector
+             * @param {HTMLElement} tabsLabel
+             */
+            _changeTab(panelSelector, tabsLabel) {
+                this._unselectTab();
+
+                tabsLabel.classList.add(TAB_IS_SELECTED);
+                this.querySelector(panelSelector).classList.add(TAB_IS_SELECTED);
+            }
+
+            /**
+             * Unselects currently selected tabs
+             */
+            _unselectTab() {
+                const forEach = Array.prototype.forEach;
+
+                forEach.call(this.querySelectorAll('.' + TAB_IS_SELECTED), function (element) {
+                    element.classList.remove(TAB_IS_SELECTED);
+                });
+            }
+        };
+    };
+})(window.eZ);

--- a/mixins/js/ez-tabs.js
+++ b/mixins/js/ez-tabs.js
@@ -6,13 +6,15 @@ window.eZ = window.eZ || {};
      * class expects the following HTML markup for tabs to work and to be styled
      * correctly:
      *
-     * <ul class="ez-tabs-list">
-     *   <li class="ez-tabs-label is-tab-selected"><a href="#tab1">Tab 1</a></li>
-     *   <li class="ez-tabs-label"><a href="#tab2">Tab 2</a></li>
-     * </ul>
-     * <div class="ez-tabs-panels">
-     *   <div class="ez-tabs-panel is-tab-selected" id="tab1">Some content</div>
-     *   <div class="ez-tabs-panel" id="tab2">Some other content</div>
+     * <div class="ez-tabs">
+     *   <ul class="ez-tabs-list">
+     *     <li class="ez-tabs-label is-tab-selected"><a href="#tab1">Tab 1</a></li>
+     *     <li class="ez-tabs-label"><a href="#tab2">Tab 2</a></li>
+     *   </ul>
+     *   <div class="ez-tabs-panels">
+     *     <div class="ez-tabs-panel is-tab-selected" id="tab1">Some content</div>
+     *     <div class="ez-tabs-panel" id="tab2">Some other content</div>
+     *   </div>
      * </div>
      *
      * Among others standard APIs, this component relies on `Element.closest`.

--- a/test/mixins/ez-tabs.html
+++ b/test/mixins/ez-tabs.html
@@ -1,0 +1,50 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
+
+        <title>ez-tabs test</title>
+
+        <script src="../../../webcomponentsjs/webcomponents-lite.js"></script>
+        <script src="../../../web-component-tester/browser.js"></script>
+
+        <link rel="import" href="../../../polymer/polymer-element.html">
+        <link rel="import" href="../../mixins/ez-tabs.html">
+        <script>
+        window.addEventListener('WebComponentsReady', function () {
+            class TestElement extends eZ.TabsMixin(Polymer.Element) {
+                static get is() {
+                    return 'ez-test-tabs';
+                }
+            }
+
+            window.customElements.define(TestElement.is, TestElement);
+        });
+        </script>
+    </head>
+    <body>
+
+        <test-fixture id="BasicTestFixture">
+            <template>
+                <ez-test-tabs>
+                    <ul class="ez-tabs-list">
+                        <li class="ez-tabs-label is-tab-selected"><a href="#tab1">Tab 1</a></li>
+                        <li class="ez-tabs-label"><a href="#tab2" class="tab-label">Tab 2</a></li>
+                    </ul>
+                    <div class="ez-tabs-panels">
+                        <div class="ez-tabs-panel is-tab-selected" id="tab1">
+                            <a href="#whatever" class="not-tabs-label">Not tabs label link</a>
+                            Some content
+                        </div>
+                        <div class="ez-tabs-panel" id="tab2">
+                            Some other content
+                        </div>
+                    </div>
+                </ez-test-tabs>
+            </template>
+        </test-fixture>
+
+        <script src="js/ez-tabs.js"></script>
+    </body>
+</html>

--- a/test/mixins/ez-tabs.html
+++ b/test/mixins/ez-tabs.html
@@ -7,6 +7,7 @@
         <title>ez-tabs test</title>
 
         <script src="../../../webcomponentsjs/webcomponents-lite.js"></script>
+        <script src="../../../element-matches/closest.js"></script><!-- for Edge 14 -->
         <script src="../../../web-component-tester/browser.js"></script>
 
         <link rel="import" href="../../../polymer/polymer-element.html">

--- a/test/mixins/js/ez-tabs.js
+++ b/test/mixins/js/ez-tabs.js
@@ -1,0 +1,51 @@
+describe('ez-tabs', function () {
+    let element;
+
+    beforeEach(function () {
+        element = fixture('BasicTestFixture');
+    });
+
+    it('should define the eZ.TabsMixin', function () {
+        assert.isFunction(window.eZ.TabsMixin);
+    });
+
+    describe('swich tab', function () {
+        function simulateClick(element) {
+            element.dispatchEvent(new CustomEvent('click', {
+                bubbles: true,
+            }));
+        }
+
+        it('should change tab', function () {
+            const label = element.querySelector('.tab-label');
+            const selected = element.querySelector('.is-tab-selected');
+
+            simulateClick(label);
+
+            Array.prototype.forEach.call(selected, function (el) {
+                assert.isFalse(
+                    el.classList.contains('is-tab-selected'),
+                    'The selected element should not be selected anymore'
+                );
+            });
+            assert.isTrue(
+                label.parentNode.classList.contains('is-tab-selected'),
+                'A new tab should be selected'
+            );
+            assert.isTrue(
+                element.querySelector(label.getAttribute('href')).classList.contains('is-tab-selected'),
+                'A new panel should be visible'
+            );
+        });
+
+        it('should ignore click on elements other than tabs label', function () {
+            const initialContent = element.innerHTML;
+
+            simulateClick(element.querySelector('.not-tabs-label'));
+            assert.equal(
+                initialContent,
+                element.innerHTML
+            );
+        });
+    });
+});

--- a/wct.conf.json
+++ b/wct.conf.json
@@ -1,5 +1,5 @@
 {
-    "suites": ["test/*.html"],
+    "suites": ["test/*.html", "test/mixins/*.html"],
     "plugins": {
         "sauce": {
             "browsers": [{


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-27450

# Description

This brings a basic ez-tabs mixin that can be used on any custom element that is supposed to handle tabs.

See https://github.com/ezsystems/hybrid-platform-ui/pull/14 for a use example

Quick screencast:


[![](https://img.youtube.com/vi/V17C4My4LT0/0.jpg)](http://www.youtube.com/watch?v=V17C4My4LT0 "Click to play on Youtube.com")

# Tests

manual tests + unit tests