### PR TITLE
EZP-27480: Prevent browser URI update when getting an AJAX error

### DIFF
--- a/test/js/ez-platform-ui-app.js
+++ b/test/js/ez-platform-ui-app.js
@@ -509,6 +509,21 @@ describe('ez-platform-ui-app', function() {
                     attributeFilter: ['updating'],
                 });
             });
+
+            describe('server error', function () {
+                it('should prevent browser URI update', function () {
+                    const doNotExist = '/i/do/not/exist';
+
+                    element.addEventListener('ez:app:updated', function () {
+                        assert.notEqual(
+                            element.url,
+                            doNotExist,
+                            'The URI should remain the same after an error'
+                        );
+                    });
+                    element.url = '/i/do/not/exist';
+                });
+            });
         });
     });
 


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-27480

# Description

This patch changes the app behaviour to keep the previous URL when navigating and this results in a server error response.

# Tests

manual test + unit test (waiting for Sauce Labs to validate the behavior in Edge/Safari though)