### PR TITLE
EZP-27459: Add the ez-notification custom element

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -10,6 +10,7 @@
     "globals": {
         "Polymer": false,
         "fixture": false,
+        "flush": false,
         "assert": false,
         "sinon": false,
         "Promise": false

--- a/core-components.html
+++ b/core-components.html
@@ -1,3 +1,4 @@
 <link rel="import" href="ez-platform-ui-app.html">
 <link rel="import" href="ez-navigation-hub.html">
 <link rel="import" href="ez-toolbar.html">
+<link rel="import" href="ez-notification.html">

--- a/demo/ez-notification.html
+++ b/demo/ez-notification.html
@@ -19,7 +19,15 @@
 
             ez-notification[type="success"] {
                 background: palegreen;
-            };
+            }
+
+            ez-notification[type="custom"] {
+                padding: 1em;
+                background: royalblue;
+                --ez-notification-copy-font-size: 0.7em;
+                --ez-notification-copy-border-color: #000;
+                color: #000;
+            }
 
             #notification-bar {
                 margin-top: 1em;
@@ -60,7 +68,9 @@
                     <button class="add-notification" data-type="error" data-timeout="0" data-copyable data-details="Some details">
                         Add a copyable error notification (timeout 0)
                     </button>
-                    <div id="notification-bar"></div>
+                    <div id="notification-bar">
+                        <ez-notification type="custom" timeout="0" copyable><p>I'm a custom notification to test CSS style<br>Copy button border color is set to #000 and font-size set to 0.7em</p></ez-notification>
+                    </div>
                 </template>
             </demo-snippet>
         </div>

--- a/demo/ez-notification.html
+++ b/demo/ez-notification.html
@@ -1,0 +1,63 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
+
+        <title>ez-notification demo</title>
+
+        <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+
+        <link rel="import" href="../../iron-demo-helpers/demo-snippet.html">
+        <link rel="import" href="../ez-notification.html">
+
+        <style>
+            ez-notification[type="error"] {
+                background: firebrick;
+                color: #fff;
+            }
+
+            ez-notification[type="success"] {
+                background: palegreen;
+            };
+
+            #notification-bar {
+                margin-top: 1em;
+            }
+        </style>
+    </head>
+    <body>
+        <div class="vertical-section-container centered">
+            <h3>Basic ez-toolbar demo</h3>
+            <demo-snippet>
+                <template>
+                    <script>
+                    (function () {
+                        const buttons = document.querySelectorAll('.add-notification');
+
+                        Array.prototype.forEach.call(buttons, function (button) {
+                            button.addEventListener('click', function () {
+                                const bar = document.getElementById('notification-bar');
+                                const notification = document.createElement('ez-notification');
+
+                                notification.timeout = parseInt(this.getAttribute('data-timeout'), 10);
+                                notification.type = this.getAttribute('data-type');
+
+                                notification.innerHTML = '<p>Hey I\'m a notification</p>';
+                                bar.appendChild(notification);
+                            });
+                        });
+                    })();
+                    </script>
+                    <button class="add-notification" data-type="success" data-timeout="5">
+                        Add a successful notification (timeout 5)
+                    </button>
+                    <button class="add-notification" data-type="error" data-timeout="0">
+                        Add an error notification (timeout 0)
+                    </button>
+                    <div id="notification-bar"></div>
+                </template>
+            </demo-snippet>
+        </div>
+    </body>
+</html>

--- a/demo/ez-notification.html
+++ b/demo/ez-notification.html
@@ -42,6 +42,8 @@
 
                                 notification.timeout = parseInt(this.getAttribute('data-timeout'), 10);
                                 notification.type = this.getAttribute('data-type');
+                                notification.copyable = this.hasAttribute('data-copyable');
+                                notification.details = this.getAttribute('data-details');
 
                                 notification.innerHTML = '<p>Hey I\'m a notification</p>';
                                 bar.appendChild(notification);
@@ -54,6 +56,9 @@
                     </button>
                     <button class="add-notification" data-type="error" data-timeout="0">
                         Add an error notification (timeout 0)
+                    </button>
+                    <button class="add-notification" data-type="error" data-timeout="0" data-copyable data-details="Some details">
+                        Add a copyable error notification (timeout 0)
                     </button>
                     <div id="notification-bar"></div>
                 </template>

--- a/demo/index.html
+++ b/demo/index.html
@@ -11,6 +11,7 @@
         <li><a href="ez-platform-ui-app.html">ez-platform-ui-app</a></li>
         <li><a href="ez-navigation-hub.html">ez-navigation-hub</a></li>
         <li><a href="ez-toolbar.html">ez-toolbar</a></li>
+        <li><a href="ez-notification.html">ez-notification</a></li>
     </ul>
   </body>
 </html>

--- a/ez-notification.html
+++ b/ez-notification.html
@@ -11,14 +11,26 @@
 
             .tools {
                 display: flex;
+                justify-content: flex-end;
+                align-items: center;
             }
 
             button {
+                flex: 0;
                 color: inherit;
                 background: transparent;
                 border: 0;
-                padding: 0 0.5em;
+                line-height: inherit;
+                padding: 0.3em 0.5em;
                 font-weight: bold;
+                cursor: pointer;
+            }
+
+            .copy {
+                flex: 1;
+                border: 2px solid var(--ez-notification-copy-border-color, #fff);
+                border-radius: 4px;
+                font-size: var(--ez-notification-copy-font-size, 1em);
             }
 
             .details {

--- a/ez-notification.html
+++ b/ez-notification.html
@@ -1,4 +1,5 @@
 <link rel="import" href="../polymer/polymer-element.html">
+<link rel="import" href="../polymer/lib/elements/dom-if.html">
 
 <dom-module id="ez-notification">
     <template>
@@ -8,16 +9,39 @@
                 justify-content: space-between;
             }
 
-            :host .ez-notification-close {
+            .tools {
+                display: flex;
+            }
+
+            button {
                 color: inherit;
                 background: transparent;
                 border: 0;
                 padding: 0 0.5em;
                 font-weight: bold;
             }
+
+            .details {
+                position: fixed;
+                bottom: 0;
+                left: 0;
+                width: 1em;
+                height: 1em;
+                display: none;
+            }
+
+            .details.copying {
+                display: block;
+            }
         </style>
-        <div class="ez-notification-content"><slot></slot></div>
-        <button class="ez-notification-close" on-click="remove" type="button">🞪</button>
+        <div class="content"><slot></slot></div>
+        <div class="tools">
+            <template is="dom-if" if="[[copyable]]">
+                <textarea class="details">[[details]]</textarea>
+                <button class="copy" on-click="_copyDetails" type="button">Copy message</button><!-- TODO should be translatable -->
+            </template>
+            <button class="close" on-click="remove" type="button">🞪</button>
+        </div>
     </template>
     <script src="js/ez-notification.js"></script>
 </dom-module>

--- a/ez-notification.html
+++ b/ez-notification.html
@@ -1,0 +1,23 @@
+<link rel="import" href="../polymer/polymer-element.html">
+
+<dom-module id="ez-notification">
+    <template>
+        <style>
+            :host {
+                display: flex;
+                justify-content: space-between;
+            }
+
+            :host .ez-notification-close {
+                color: inherit;
+                background: transparent;
+                border: 0;
+                padding: 0 0.5em;
+                font-weight: bold;
+            }
+        </style>
+        <div class="ez-notification-content"><slot></slot></div>
+        <button class="ez-notification-close" on-click="remove" type="button">🞪</button>
+    </template>
+    <script src="js/ez-notification.js"></script>
+</dom-module>

--- a/ez-platform-ui-app.html
+++ b/ez-platform-ui-app.html
@@ -1,4 +1,5 @@
 <link rel="import" href="../polymer/polymer-element.html">
+<link rel="import" href="ez-notification.html">
 
 <style>
     ez-platform-ui-app {

--- a/js/ez-notification.js
+++ b/js/ez-notification.js
@@ -1,0 +1,79 @@
+(function () {
+    /**
+     * <ez-notification> represents a notification in the application. If a
+     * timeout is provided, the notification automatically disappears after
+     * timeout seconds otherwise, the user has to use the close button.
+     *
+     * Example:
+     *
+     * ```
+     * <ez-notification type="error" timeout="10">
+     *   <p>
+     *      <em>Oops</em>
+     *      there was an error some where, but I'll be removed after 10 seconds
+     *   </p>
+     * </ez-notification>
+     * ```
+     *
+     * @polymerElement
+     * @demo demo/ez-notification.html
+     */
+    class Notification extends Polymer.Element {
+        static get is() {
+            return 'ez-notification';
+        }
+
+        static get properties() {
+            return {
+                /**
+                 * The notification type. This property is reflected as an
+                 * attribute so that it's possible to style notification
+                 * depending this value.
+                 */
+                type: {
+                    type: String,
+                    reflectToAttribute: true,
+                    value: '',
+                },
+
+                /**
+                 * The notification timeout. After timeout seconds, the
+                 * notification is automatically removed.
+                 */
+                timeout: {
+                    type: Number,
+                    value: 0,
+                    observer: '_setTimeout',
+                },
+            };
+        }
+
+        /**
+         * Schedules the notification removal after `timeout` second. It's an
+         * observer of the `timeout` property.
+         *
+         * @param {Number} timeout
+         */
+        _setTimeout(timeout) {
+            this._clearTimeout();
+            if ( timeout ) {
+                this._timeoutID = setTimeout(this.remove.bind(this), timeout * 1000);
+            }
+        }
+
+        /**
+         * Removes the scheduled notification removal if any
+         */
+        _clearTimeout() {
+            if ( this._timeoutID ) {
+                clearTimeout(this._timeoutID);
+            }
+        }
+
+        disconnectedCallback() {
+            this._clearTimeout();
+        }
+    }
+
+    window.customElements.define(Notification.is, Notification);
+})();

--- a/js/ez-notification.js
+++ b/js/ez-notification.js
@@ -5,7 +5,13 @@
      * timeout seconds otherwise, the user has to use the close button.
      *
      * Also, this element accepts a `details` property that can be copied when
-     * `copyable` property is set to true.
+     * `copyable` property is set to true with a "Copy to clipboard" button.
+     * The copy to clipboard button can be styled with 2 custom properties:
+     *
+     * - `--ez-notification-copy-border-color` to set the button border color
+     *   (white by default)
+     * - `--ez-notification-copy-font-size` to set the button font size color
+     *   (1em by default)
      *
      * Example:
      *

--- a/js/ez-notification.js
+++ b/js/ez-notification.js
@@ -4,6 +4,9 @@
      * timeout is provided, the notification automatically disappears after
      * timeout seconds otherwise, the user has to use the close button.
      *
+     * Also, this element accepts a `details` property that can be copied when
+     * `copyable` property is set to true.
+     *
      * Example:
      *
      * ```
@@ -45,6 +48,23 @@
                     value: 0,
                     observer: '_setTimeout',
                 },
+
+                /**
+                 * Indicates whether `details` can be copied using a copy button
+                 * integrated in the notification.
+                 */
+                copyable: {
+                    type: Boolean,
+                    value: false,
+                },
+
+                /**
+                 * Holds details about the notification. If `copyable` is true,
+                 * this can be copied to the clipboard.
+                 */
+                details: {
+                    type: String,
+                },
             };
         }
 
@@ -68,6 +88,21 @@
             if ( this._timeoutID ) {
                 clearTimeout(this._timeoutID);
             }
+        }
+
+        /**
+         * Copies `details` property value to the clipboard.
+         * It's a click event listener on the copy button.
+         */
+        _copyDetails() {
+            const details = this.shadowRoot.querySelector('.details');
+
+            // `copying` make sure the corresponding `textarea` can receive the
+            // focus so that we can select its content and copy it.
+            details.classList.add('copying');
+            details.select();
+            document.execCommand('copy');
+            details.classList.remove('copying');
         }
 
         disconnectedCallback() {

--- a/js/ez-platform-ui-app.js
+++ b/js/ez-platform-ui-app.js
@@ -113,6 +113,28 @@
                     value: location.href,
                     observer: '_triggerUpdate',
                 },
+
+                /**
+                 * Array of notifications to display to the user. A notification
+                 * is described by an object with the following properties:
+                 *
+                 * - `type` a String representing the type of the notification
+                 *   (`error`, `processing`, `positive`, ...)
+                 * - `timeout` a Number of seconds after which the notification
+                 *   will disappear. 0 means the notification will not disappear
+                 *   by itself
+                 * - `content` a String containing the HTML to display to the
+                 *   user.
+                 * - [optional] `details` a String containing details about the
+                 *   notification
+                 * - [optional] `copyable` a Boolean, if true the user will see
+                 *   a button a copy button to copy the notification details to
+                 *   its clipboard.
+                 */
+                notifications: {
+                    type: Array,
+                    observer: '_renderNotifications',
+                },
             };
         }
 
@@ -128,6 +150,30 @@
          */
         _setPageTitle(newValue) {
             this.ownerDocument.title = newValue;
+        }
+
+        /**
+         * Renders the given `notifications` in the app. It's an observer of the
+         * `notifications` property.
+         *
+         * @param {Array} notifications
+         */
+        _renderNotifications(notifications) {
+            const bar = this.querySelector('#ez-notification-bar');
+
+            if ( !notifications ) {
+                return;
+            }
+            notifications.forEach((info) => {
+                const notification = this.ownerDocument.createElement('ez-notification');
+
+                notification.type = info.type;
+                notification.timeout = parseInt(info.timeout, 10);
+                notification.details = info.details;
+                notification.copyable = !!info.copyable;
+                notification.innerHTML = info.content;
+                bar.appendChild(notification);
+            });
         }
 
         /**

--- a/test/ez-notification.html
+++ b/test/ez-notification.html
@@ -27,6 +27,12 @@
             </template>
         </test-fixture>
 
+        <test-fixture id="CopyableElement">
+            <template>
+                <ez-notification details="some details" copyable></ez-notification>
+            </template>
+        </test-fixture>
+
         <script src="js/ez-notification.js"></script>
     </body>
 </html>

--- a/test/ez-notification.html
+++ b/test/ez-notification.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
+
+        <title>ez-notification test</title>
+
+        <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+        <script src="../../web-component-tester/browser.js"></script>
+
+        <link rel="import" href="../ez-notification.html">
+    </head>
+    <body>
+
+        <test-fixture id="BasicTestFixture">
+            <template>
+                <ez-notification></ez-notification>
+            </template>
+        </test-fixture>
+
+        <test-fixture id="WithContentTestFixture">
+            <template>
+                <ez-notification>
+                    <p class="notification-content">I'm the notification content</p>
+                </ez-notification>
+            </template>
+        </test-fixture>
+
+        <script src="js/ez-notification.js"></script>
+    </body>
+</html>

--- a/test/ez-platform-ui-app.html
+++ b/test/ez-platform-ui-app.html
@@ -74,6 +74,14 @@
             </template>
         </test-fixture>
 
+        <test-fixture id="NotificationsTestFixture">
+            <template>
+                <ez-platform-ui-app>
+                    <div id="ez-notification-bar"></div>
+                </ez-platform-ui-app>
+            </template>
+        </test-fixture>
+
         <script src="js/ez-platform-ui-app.js"></script>
     </body>
 </html>

--- a/test/js/ez-notification.js
+++ b/test/js/ez-notification.js
@@ -1,0 +1,82 @@
+describe('ez-notification', function() {
+    let element;
+
+    beforeEach(function () {
+        element = fixture('BasicTestFixture');
+    });
+
+    it('should be defined', function () {
+        assert.equal(
+            window.customElements.get('ez-notification'),
+            element.constructor
+        );
+    });
+
+    describe('properties', function () {
+        describe('`type`', function () {
+            it('should default to an empty string', function () {
+                assert.equal('', element.type);
+            });
+
+            describe('set', function () {
+                it('should be reflected to an attribute', function () {
+                    element.type = 'whatever';
+
+                    assert.equal(
+                        element.type,
+                        element.getAttribute('type')
+                    );
+                });
+            });
+        });
+
+        describe('`timeout`', function () {
+            it('should default to 0', function () {
+                assert.equal(0, element.timeout);
+            });
+        });
+    });
+
+    describe('content', function () {
+        let elementWithContent;
+
+        beforeEach(function () {
+            elementWithContent = fixture('WithContentTestFixture');
+        });
+
+        it('should be distributed in the default slot', function () {
+            const content = elementWithContent.querySelector('.notification-content');
+
+            assert.isNotNull(content.assignedSlot);
+        });
+    });
+
+    describe('removal', function () {
+        it('should be automatic after timeout second', function (done) {
+            const parent = element.parentNode;
+
+            element.timeout = 0.1;
+
+            setTimeout(function () {
+                assert.isNull(
+                    parent.querySelector('ez-notification'),
+                    'The notification should have been removed'
+                );
+                done();
+            }, element.timeout * 1.5 * 1000);
+        });
+    });
+
+    describe('close button', function () {
+        it('should remove the notification', function () {
+            const parent = element.parentNode;
+
+            element.shadowRoot.querySelector('button').dispatchEvent(new CustomEvent('click', {
+                bubbles: true,
+                cancelable: true,
+            }));
+
+            assert.isNull(parent.querySelector('ez-notification'));
+        });
+    });
+});

--- a/test/js/ez-platform-ui-app.js
+++ b/test/js/ez-platform-ui-app.js
@@ -148,6 +148,85 @@ describe('ez-platform-ui-app', function() {
                 });
             });
         });
+
+        describe('`notifications`', function () {
+            let notifElement;
+
+            beforeEach(function () {
+                notifElement = fixture('NotificationsTestFixture');
+            });
+
+            function assertNotification(object, element) {
+                Object.keys(object).forEach(function (prop) {
+                    if ( prop === 'content' ) {
+                        assert.strictEqual(
+                            object[prop], element.innerHTML,
+                            'The ez-notification content should have been set from the notification object'
+                        );
+                    } else {
+                        assert.strictEqual(
+                            object[prop], element[prop],
+                            `The ez-notification property '${prop}' should have been set from the object`
+                        );
+                    }
+                });
+            }
+
+            it('should ignore falsy value', function () {
+                element.notifications = '';
+            });
+
+            it('should render notifications', function () {
+                const notification1 = {
+                    type: 'error',
+                    timeout: 0,
+                    content: 'whatever',
+                    copyable: true,
+                    details: 'whatever2',
+                };
+                const notification2 = {
+                    type: 'success',
+                    timeout: 10,
+                    content: '2',
+                    copyable: false,
+                    details: 'details 2',
+                };
+
+                notifElement.notifications = [notification1, notification2];
+
+                const elements = notifElement.querySelectorAll('ez-notification');
+
+                assert.equal(
+                    notifElement.notifications.length, elements.length,
+                    `${notifElement.notifications.length} notifications should have been created`
+                );
+                assertNotification(notification1, elements[0]);
+                assertNotification(notification2, elements[1]);
+            });
+
+            it('should convert notification `timeout` to a number', function () {
+                const notification = {
+                    type: 'error',
+                    timeout: '0',
+                    content: 'whatever',
+                };
+
+                notifElement.notifications = [notification];
+                assert.strictEqual(0, notifElement.querySelector('ez-notification').timeout);
+            });
+
+            it('should convert notification `copyable` to a boolean', function () {
+                const notification = {
+                    type: 'error',
+                    timeout: '0',
+                    content: 'whatever',
+                    copyable: 'true',
+                };
+
+                notifElement.notifications = [notification];
+                assert.isTrue(notifElement.querySelector('ez-notification').copyable);
+            });
+        });
     });
 
     describe('enhance navigation', function () {


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-27459

# Description

This patch adds a `<ez-notification>` custom element to represent a notification in the application. Besides displaying some HTML to the user, a notification can auto-disappear after `timeout` seconds and if it is set as `copyable`, a button allows to copy the content of the `details` notification property.

See screencast in https://github.com/ezsystems/hybrid-platform-ui-core-components/pull/20

* [x] Base implementation
* [x] Copy to clipboard / Details support
* [x] CSS
* [ ] ~~Think about icon for close button~~ https://jira.ez.no/browse/EZP-27407
* [ ] ~~Translation support for "Copy to clipboard" label (and maybe for a title on the close button)~~ https://jira.ez.no/browse/EZP-27527

# Tests

manual test and unit test
