### PR TITLE
EZP-27481: Notifications in ez-platform-ui-app

### DIFF
--- a/ez-platform-ui-app.html
+++ b/ez-platform-ui-app.html
@@ -1,4 +1,5 @@
 <link rel="import" href="../polymer/polymer-element.html">
+<link rel="import" href="ez-notification.html">
 
 <style>
     ez-platform-ui-app {

--- a/js/ez-platform-ui-app.js
+++ b/js/ez-platform-ui-app.js
@@ -113,6 +113,28 @@
                     value: location.href,
                     observer: '_triggerUpdate',
                 },
+
+                /**
+                 * Array of notifications to display to the user. A notification
+                 * is described by an object with the following properties:
+                 *
+                 * - `type` a String representing the type of the notification
+                 *   (`error`, `processing`, `positive`, ...)
+                 * - `timeout` a Number of seconds after which the notification
+                 *   will disappear. 0 means the notification will not disappear
+                 *   by itself
+                 * - `content` a String containing the HTML to display to the
+                 *   user.
+                 * - [optional] `details` a String containing details about the
+                 *   notification
+                 * - [optional] `copyable` a Boolean, if true the user will see
+                 *   a button a copy button to copy the notification details to
+                 *   its clipboard.
+                 */
+                notifications: {
+                    type: Array,
+                    observer: '_renderNotifications',
+                },
             };
         }
 
@@ -128,6 +150,30 @@
          */
         _setPageTitle(newValue) {
             this.ownerDocument.title = newValue;
+        }
+
+        /**
+         * Renders the given `notifications` in the app. It's an observer of the
+         * `notifications` property.
+         *
+         * @param {Array} notifications
+         */
+        _renderNotifications(notifications) {
+            const bar = this.querySelector('#ez-notification-bar');
+
+            if ( !notifications ) {
+                return;
+            }
+            notifications.forEach((info) => {
+                const notification = this.ownerDocument.createElement('ez-notification');
+
+                notification.type = info.type;
+                notification.timeout = parseInt(info.timeout, 10);
+                notification.details = info.details;
+                notification.copyable = !!info.copyable;
+                notification.innerHTML = info.content;
+                bar.appendChild(notification);
+            });
         }
 
         /**

--- a/test/ez-platform-ui-app.html
+++ b/test/ez-platform-ui-app.html
@@ -74,6 +74,14 @@
             </template>
         </test-fixture>
 
+        <test-fixture id="NotificationsTestFixture">
+            <template>
+                <ez-platform-ui-app>
+                    <div id="ez-notification-bar"></div>
+                </ez-platform-ui-app>
+            </template>
+        </test-fixture>
+
         <script src="js/ez-platform-ui-app.js"></script>
     </body>
 </html>

--- a/test/js/ez-platform-ui-app.js
+++ b/test/js/ez-platform-ui-app.js
@@ -148,6 +148,85 @@ describe('ez-platform-ui-app', function() {
                 });
             });
         });
+
+        describe('`notifications`', function () {
+            let notifElement;
+
+            beforeEach(function () {
+                notifElement = fixture('NotificationsTestFixture');
+            });
+
+            function assertNotification(object, element) {
+                Object.keys(object).forEach(function (prop) {
+                    if ( prop === 'content' ) {
+                        assert.strictEqual(
+                            object[prop], element.innerHTML,
+                            'The ez-notification content should have been set from the notification object'
+                        );
+                    } else {
+                        assert.strictEqual(
+                            object[prop], element[prop],
+                            `The ez-notification property '${prop}' should have been set from the object`
+                        );
+                    }
+                });
+            }
+
+            it('should ignore falsy value', function () {
+                element.notifications = '';
+            });
+
+            it('should render notifications', function () {
+                const notification1 = {
+                    type: 'error',
+                    timeout: 0,
+                    content: 'whatever',
+                    copyable: true,
+                    details: 'whatever2',
+                };
+                const notification2 = {
+                    type: 'success',
+                    timeout: 10,
+                    content: '2',
+                    copyable: false,
+                    details: 'details 2',
+                };
+
+                notifElement.notifications = [notification1, notification2];
+
+                const elements = notifElement.querySelectorAll('ez-notification');
+
+                assert.equal(
+                    notifElement.notifications.length, elements.length,
+                    `${notifElement.notifications.length} notifications should have been created`
+                );
+                assertNotification(notification1, elements[0]);
+                assertNotification(notification2, elements[1]);
+            });
+
+            it('should convert notification `timeout` to a number', function () {
+                const notification = {
+                    type: 'error',
+                    timeout: '0',
+                    content: 'whatever',
+                };
+
+                notifElement.notifications = [notification];
+                assert.strictEqual(0, notifElement.querySelector('ez-notification').timeout);
+            });
+
+            it('should convert notification `copyable` to a boolean', function () {
+                const notification = {
+                    type: 'error',
+                    timeout: '0',
+                    content: 'whatever',
+                    copyable: 'true',
+                };
+
+                notifElement.notifications = [notification];
+                assert.isTrue(notifElement.querySelector('ez-notification').copyable);
+            });
+        });
     });
 
     describe('enhance navigation', function () {


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-27481
Related to https://github.com/ezsystems/hybrid-platform-ui/pull/26 and https://github.com/ezsystems/hybrid-platform-ui-core-components/pull/19

# Description

This patch adds a `notifications` property to the `<ez-platform-ui-app>` component so that the server can issue notifications. For now, [the server side part is not implemented yet](https://jira.ez.no/browse/EZP-27476) so for the screencast I added some buttons and a textarea on the dashboard:

[![](https://img.youtube.com/vi/N4JlQ_czK_c/0.jpg)](http://www.youtube.com/watch?v=N4JlQ_czK_c "Click to play on Youtube.com")


# Tests

manual test and unit tests