### PR TITLE
EZP-27569: Asynchronously load hidden Content view tabs

### DIFF
--- a/core-components.html
+++ b/core-components.html
@@ -5,3 +5,4 @@
 <link rel="import" href="ez-server-side-content.html">
 <link rel="import" href="ez-browse.html">
 <link rel="import" href="ez-content-view.html">
+<link rel="import" href="ez-asynchronous-block.html">

--- a/demo/asynchronous-load-navigation.html
+++ b/demo/asynchronous-load-navigation.html
@@ -1,0 +1,4 @@
+<p>Local to the block navigation happened!</p>
+<div class="ez-js-local-navigation">
+    <p><a href="asynchronous-load.html">Return to previous state</a></p>
+</div>

--- a/demo/asynchronous-load.html
+++ b/demo/asynchronous-load.html
@@ -1,0 +1,2 @@
+<p>Hey, I was loaded <strong>asynchronously</strong></p>
+<p><em>Cool</em>, isn't it?</p>

--- a/demo/asynchronous-load.html
+++ b/demo/asynchronous-load.html
@@ -1,2 +1,3 @@
 <p>Hey, I was loaded <strong>asynchronously</strong></p>
 <p><em>Cool</em>, isn't it?</p>
+<p><a href="asynchronous-load-navigation.html" class="ez-js-local-navigation">Here is a link that should update the block</a></p>

--- a/demo/ez-asynchronous-block.html
+++ b/demo/ez-asynchronous-block.html
@@ -1,0 +1,60 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
+
+        <title>ez-asynchronous-block demo</title>
+
+        <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+
+        <link rel="import" href="../../iron-demo-helpers/demo-snippet.html">
+        <link rel="import" href="../ez-asynchronous-block.html">
+
+        <style>
+            ez-asynchronous-block[loading] {
+                opacity: 0.3;
+            }
+
+            ez-asynchronous-block {
+                opacity: 1;
+                transition: opacity 0.3s ease;
+            }
+        </style>
+    </head>
+    <body>
+        <div class="vertical-section-container centered">
+            <h3>ez-asynchronous-block demo</h3>
+            <demo-snippet>
+                <template>
+                    <ez-asynchronous-block url="asynchronous-load.html">Waiting to start loading</ez-asynchronous-block>
+                    <button class="load">Load the asynchronous block</button>
+                    <button class="error">Trigger error</button>
+                    <h2>Event log</h2>
+                    <div id="log"></div>
+                    <script>
+                        const button = document.querySelector('.load');
+                        const err = document.querySelector('.error');
+                        const asyncBlock = document.querySelector('ez-asynchronous-block');
+                        const log = document.getElementById('log');
+
+                        button.addEventListener('click', function () {
+                            asyncBlock.url = asyncBlock.getAttribute('url');
+                            asyncBlock.load();
+                        });
+                        err.addEventListener('click', function () {
+                            asyncBlock.url = 'http://itdoesnotexist.test/';
+                            asyncBlock.load();
+                        });
+                        asyncBlock.addEventListener('ez:asynchronousBlock:updated', function () {
+                            log.innerHTML += '<p><code>ez:asynchronousBlock:updated</code> event</p>';
+                        });
+                        asyncBlock.addEventListener('ez:asynchronousBlock:error', function (e) {
+                            log.innerHTML += `<p><code>ez:asynchronousBlock:error</code> event (${e.detail.error})</p>`;
+                        });
+                    </script>
+                </template>
+            </demo-snippet>
+        </div>
+    </body>
+</html>

--- a/demo/ez-content-view.html
+++ b/demo/ez-content-view.html
@@ -20,7 +20,9 @@
                         <div class="ez-tabs">
                             <ul class="ez-tabs-list">
                                 <li class="ez-tabs-label is-tab-selected"><a href="#tab1">Tab 1</a></li>
+                                <li class="ez-tabs-label"><a href="#async-tab">Asynchronous tab</a></li>
                                 <li class="ez-tabs-label"><a href="#tab2">Tab 2</a></li>
+                                <li class="ez-tabs-label"><a href="#broken-async-tab">Broken asynchronous tab</a></li>
                             </ul>
                             <div class="ez-tabs-panels">
                                 <div class="ez-tabs-panel is-tab-selected" id="tab1">
@@ -31,9 +33,20 @@
                                     <p>This is the content of <em>Tab 2</em></p>
                                     <p>Click on <em>Tab 1</em> to switch to the other tab</p>
                                 </div>
+                                <ez-asynchronous-block class="ez-tabs-panel" id="async-tab" url="asynchronous-load.html"></ez-asynchronous-block>
+                                <ez-asynchronous-block class="ez-tabs-panel" id="broken-async-tab" url="does-not-exist.html"></ez-asynchronous-block>
                             </div>
                         </div>
                     </ez-content-view>
+                    <hr>
+                    <div id="log">
+                        <h2>Event log</h2>
+                    </div>
+                    <script>
+                        document.addEventListener('ez:notify', function (e) {
+                            document.querySelector('#log').innerHTML += e.detail.notification.content;
+                        });
+                    </script>
                 </template>
             </demo-snippet>
         </div>

--- a/demo/index.html
+++ b/demo/index.html
@@ -15,6 +15,7 @@
         <li><a href="ez-server-side-content.html">ez-server-side-content</a></li>
         <li><a href="ez-browse.html">ez-browse</a></li>
         <li><a href="ez-content-view.html">ez-content-view</a></li>
+        <li><a href="ez-asynchronous-block.html">ez-asynchronous-block</a></li>
     </ul>
   </body>
 </html>

--- a/ez-asynchronous-block.html
+++ b/ez-asynchronous-block.html
@@ -1,4 +1,5 @@
 <link rel="import" href="../polymer/polymer-element.html">
+<link rel="import" href="mixins/ez-ajax-fetcher.html">
 
 <style>
     ez-asynchronous-block {

--- a/ez-asynchronous-block.html
+++ b/ez-asynchronous-block.html
@@ -1,0 +1,8 @@
+<link rel="import" href="../polymer/polymer-element.html">
+
+<style>
+    ez-asynchronous-block {
+        display: block;
+    }
+</style>
+<script src="js/ez-asynchronous-block.js"></script>

--- a/ez-content-view.html
+++ b/ez-content-view.html
@@ -1,5 +1,7 @@
 <link rel="import" href="../polymer/polymer-element.html">
+<link rel="import" href="mixins/ez-notifier.html">
 <link rel="import" href="ez-server-side-content.html">
+<link rel="import" href="ez-asynchronous-block.html">
 
 <style>
 ez-content-view {

--- a/ez-platform-ui-app.html
+++ b/ez-platform-ui-app.html
@@ -1,4 +1,5 @@
 <link rel="import" href="../polymer/polymer-element.html">
+<link rel="import" href="mixins/ez-ajax-fetcher.html">
 <link rel="import" href="ez-notification.html">
 
 <style>

--- a/js/ez-asynchronous-block.js
+++ b/js/ez-asynchronous-block.js
@@ -1,0 +1,125 @@
+(function () {
+    // FIXME: after https://jira.ez.no/browse/EZP-27582
+    // remove that function!
+    function filterTabHTMLCode(htmlCode) {
+        const doc = (new DOMParser()).parseFromString(htmlCode, 'text/html');
+        const main = doc.querySelector('main');
+
+        if ( main ) {
+            return main.innerHTML;
+        }
+        return htmlCode;
+    }
+
+    /**
+     * `<ez-asynchronous-block>` represents a block that can be loaded
+     * asynchronously. It exposes a `load()` method that will request its `url`.
+     * If the request is successful, it dispatches the
+     * `ez:asynchronousBlock:updated` event, if it's not an
+     * `ez:asynchronousBlock:error` event is dispatched.
+     *
+     * Among others standard APIs, this component relies on `fetch`. `fetch` is
+     * not supported by Safari 10.0. So for this component to work in those
+     * browser, the page should include a polyfill of this standard API.
+     *
+     * @polymerElement
+     * @demo demo/ez-asynchronous-block.html
+     */
+    class AsynchronousBlock extends Polymer.Element {
+        static get is() {
+            return 'ez-asynchronous-block';
+        }
+
+        static get properties() {
+            return {
+                /**
+                 * Indicates whether the block is correctly loading the URL
+                 */
+                loading: {
+                    type: Boolean,
+                    reflectToAttribute: true,
+                    value: false,
+                },
+
+                /**
+                 * Indicates whether the block successfully loaded.
+                 */
+                loaded: {
+                    type: Boolean,
+                    value: false,
+                },
+
+                /**
+                 * The URL to fetch to get the block content
+                 */
+                url: {
+                    type: String,
+                },
+            };
+        }
+
+        /**
+         * Loads the Asynchronous Block content. If the loading is successful,
+         * the `loaded` property is set to true and the
+         * `ez:asynchronousBlock:updated` event is dispatched.
+         */
+        load() {
+            const fetchOptions = {
+                credentials: 'same-origin',
+                // FIXME: after https://jira.ez.no/browse/EZP-27582
+                // this is where the custom Header should be set
+                redirect: 'follow',
+            };
+
+            this.loading = true;
+            fetch(this.url, fetchOptions)
+                .then((response) => response.text())
+                .then((htmlCode) => {
+                    this.loading = false;
+                    // FIXME: after https://jira.ez.no/browse/EZP-27582
+                    // this is a workaround needed because the returned tab code
+                    // is decorated with the App Layout.
+                    // when EZP-27582 is implemented, the following line should
+                    // be:
+                    // this.innerHTML = htmlCode;
+                    this.innerHTML = filterTabHTMLCode(htmlCode);
+                    this.loaded = true;
+                    this._dispatchUpdated();
+                })
+                .catch((error) => {
+                    this.loading = false;
+                    this._dispatchError(error);
+                });
+        }
+
+        /**
+         * Dispatches the `ez:asynchronousBlock:updated` event. It is configured
+         * to bubble but it is not cancelable.
+         */
+        _dispatchUpdated() {
+            this.dispatchEvent(new CustomEvent('ez:asynchronousBlock:updated', {
+                bubbles: true,
+                cancelable: false,
+            }));
+        }
+
+        /**
+         * Dispatches the `ez:asynchronousBlock:error` event. It is configured
+         * to bubble but it is not cancelable. It also carries the `error`
+         * object
+         *
+         * @param {Error} error
+         */
+        _dispatchError(error) {
+            this.dispatchEvent(new CustomEvent('ez:asynchronousBlock:error', {
+                bubbles: true,
+                cancelable: false,
+                detail: {
+                    error: error,
+                },
+            }));
+        }
+    }
+
+    window.customElements.define(AsynchronousBlock.is, AsynchronousBlock);
+})();

--- a/js/ez-asynchronous-block.js
+++ b/js/ez-asynchronous-block.js
@@ -27,9 +27,9 @@
      *   the block will be updated with the server response.
      *
      * Among others standard APIs, this component relies on `fetch` and
-     * `Element.closest`. `fetch` is not supported by Safari 10.0 and
-     * `Element.closest` is not available in Edge 14. So for this component to
-     * work in those browser, the page should include polyfills of those
+     * `Element.matches`. `fetch` is not supported by Safari 10.0 and
+     * `Element.matches` is not available in Edge 14. So for this component to
+     * work in those browsers, the page should include polyfills of those
      * standard API.
      *
      * @polymerElement
@@ -74,7 +74,7 @@
         }
 
         /**
-         * Adds a event listeners to implement the *local* navigation.
+         * Adds event listeners to implement the *local* navigation.
          * If a user clicks on a link with the class `ez-js-local-navigation` or
          * which is descendant of an element with that class, the Asynchronous
          * Block will do the corresponding AJAX request and updates itself with

--- a/js/ez-asynchronous-block.js
+++ b/js/ez-asynchronous-block.js
@@ -1,3 +1,4 @@
+/* global eZ */
 (function () {
     // FIXME: after https://jira.ez.no/browse/EZP-27582
     // remove that function!
@@ -25,7 +26,7 @@
      * @polymerElement
      * @demo demo/ez-asynchronous-block.html
      */
-    class AsynchronousBlock extends Polymer.Element {
+    class AsynchronousBlock extends eZ.mixins.AjaxFetcher(Polymer.Element) {
         static get is() {
             return 'ez-asynchronous-block';
         }
@@ -64,15 +65,11 @@
          * `ez:asynchronousBlock:updated` event is dispatched.
          */
         load() {
-            const fetchOptions = {
-                credentials: 'same-origin',
-                // FIXME: after https://jira.ez.no/browse/EZP-27582
-                // this is where the custom Header should be set
-                redirect: 'follow',
-            };
-
             this.loading = true;
-            fetch(this.url, fetchOptions)
+            // FIXME: after https://jira.ez.no/browse/EZP-27582
+            // this._fetch should have a second parameter with the header
+            // so the server generates the HTML without the app layout
+            this._fetch(update)
                 .then((response) => {
                     if ( response.status >= 400 ) {
                         throw new Error();

--- a/js/ez-asynchronous-block.js
+++ b/js/ez-asynchronous-block.js
@@ -59,12 +59,33 @@
             };
         }
 
+        connectedCallback() {
+            super.connectedCallback();
+            this._setupFormHandling();
+        }
+
+        /**
+         * Adds a submit event listener so that forms are posted in AJAX by this
+         * component.
+         */
+        _setupFormHandling() {
+            this.addEventListener('submit', (e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                this.load(e.target);
+            });
+        }
+
         /**
          * Loads the Asynchronous Block content. If the loading is successful,
          * the `loaded` property is set to true and the
          * `ez:asynchronousBlock:updated` event is dispatched.
+         *
+         * @param {HTMLFormElement} [form]
          */
-        load() {
+        load(form) {
+            const update = form || this.url;
+
             this.loading = true;
             // FIXME: after https://jira.ez.no/browse/EZP-27582
             // this._fetch should have a second parameter with the header

--- a/js/ez-asynchronous-block.js
+++ b/js/ez-asynchronous-block.js
@@ -73,6 +73,12 @@
 
             this.loading = true;
             fetch(this.url, fetchOptions)
+                .then((response) => {
+                    if ( response.status >= 400 ) {
+                        throw new Error();
+                    }
+                    return response;
+                })
                 .then((response) => response.text())
                 .then((htmlCode) => {
                     this.loading = false;

--- a/js/ez-content-view.js
+++ b/js/ez-content-view.js
@@ -1,14 +1,53 @@
+/* global eZ */
 (function () {
+    const Base = eZ.mixins.Notifier(customElements.get('ez-server-side-content'));
+
     /**
-    * `<ez-content-view>` handles the content generated when viewing a Content item.
-    * It extends `<ez-server-side-content>`.
+     * `<ez-content-view>` handles the HTML generated when viewing a Content item.
+     * It extends `<ez-server-side-content>` and it adds the asynchronous loading
+     * of tabs.
      *
      * @polymerElement
      * @demo demo/ez-content-view.html
      */
-    class ContentView extends customElements.get('ez-server-side-content') {
+    class ContentView extends Base {
         static get is() {
             return 'ez-content-view';
+        }
+
+        connectedCallback() {
+            super.connectedCallback();
+            this._setupAsynchronousTabs();
+        }
+
+        /**
+         * Adds event listeners to load and handle error loading error of
+         * asynchronous tabs.
+         */
+        _setupAsynchronousTabs() {
+            const isAsyncPanel = function (panel) {
+                return panel instanceof customElements.get('ez-asynchronous-block');
+            };
+
+            this.addEventListener('ez:tabChange', (e) => {
+                const panel = e.detail.panel;
+
+                if ( isAsyncPanel(panel) && !panel.loaded ) {
+                    panel.load();
+                }
+            });
+            this.addEventListener('ez:asynchronousBlock:error', (e) => {
+                const labelLink = this._getLabelLink(e.target);
+
+                if ( isAsyncPanel(e.target) && labelLink ) {
+                    e.stopPropagation();
+                    this.notify({
+                        type: 'error',
+                        // FIXME: make that translatable, see https://jira.ez.no/browse/EZP-27527
+                        content: `<p>Failed to load tab <em>${labelLink.textContent}</em></p>`,
+                    });
+                }
+            });
         }
     }
 

--- a/js/ez-platform-ui-app.js
+++ b/js/ez-platform-ui-app.js
@@ -141,23 +141,25 @@
         constructor() {
             super();
             this._enhanceNavigation();
-            this._handleContentDiscover();
-            this._handleNavigateTo();
+            this._setAppEventsListeners();
         }
 
         /**
-         * Adds event listener for `ez:contentDiscover` event.
+         * Adds events listeners for the following app level events:
+         *
+         * - `ez:contentDiscover` to create a Universal Discovery element
+         * - `ez:navigateTo` to navigate to the given url
+         * - `ez:notify` to display a notification
          */
-        _handleContentDiscover() {
+        _setAppEventsListeners() {
             this.addEventListener('ez:contentDiscover', this._createUDCustomElement.bind(this));
-        }
 
-        /**
-         * Adds an event listener for the ez:navigateTo event to navigate to the url provided by the event details
-         */
-        _handleNavigateTo() {
             this.addEventListener('ez:navigateTo', (e) => {
                 this.url = e.detail.url;
+            });
+
+            this.addEventListener('ez:notify', (e) => {
+                this.notifications = [e.detail.notification];
             });
         }
 
@@ -195,21 +197,34 @@
 
         /**
          * Renders the given `notifications` in the app. It's an observer of the
-         * `notifications` property.
+         * `notifications` property. It also takes care of setting the
+         * notification `timeout` depending on the notification `type` if the
+         * timeout is not provided.
          *
          * @param {Array} notifications
          */
         _renderNotifications(notifications) {
             const bar = this.querySelector('#ez-notification-bar');
+            const DEFAULT_ERROR_TIMEOUT = 0;
+            const DEFAULT_TIMEOUT = 10;
 
             if ( !notifications ) {
                 return;
             }
             notifications.forEach((info) => {
                 const notification = this.ownerDocument.createElement('ez-notification');
+                let timeout = parseInt(info.timeout, 10);
+
+                if ( isNaN(timeout) ) {
+                    if ( info.type === 'error' ) {
+                        timeout = DEFAULT_ERROR_TIMEOUT;
+                    } else {
+                        timeout = DEFAULT_TIMEOUT;
+                    }
+                }
 
                 notification.type = info.type;
-                notification.timeout = parseInt(info.timeout, 10);
+                notification.timeout = timeout;
                 notification.details = info.details;
                 notification.copyable = !!info.copyable;
                 notification.innerHTML = info.content;

--- a/js/ez-server-side-content.js
+++ b/js/ez-server-side-content.js
@@ -3,7 +3,7 @@
     /**
      * <ez-server-side-content> allows to apply enhancement to a server side
      * generated content. For now, this class is able to handle the tabs markup
-     * thanks to the eZ.TabsMixin.
+     * thanks to the `eZ.mixins.Tabs` class expression mixin.
      *
      * Among others standard APIs, this component relies on `Element.closest`.
      * `Element.closest` is not available in Edge 14. So for this component to
@@ -13,7 +13,7 @@
      * @polymerElement
      * @demo demo/ez-server-side-content.html
      */
-    class ServerSideContent extends eZ.TabsMixin(Polymer.Element) {
+    class ServerSideContent extends eZ.mixins.Tabs(Polymer.Element) {
         static get is() {
             return 'ez-server-side-content';
         }

--- a/mixins/ez-ajax-fetcher.html
+++ b/mixins/ez-ajax-fetcher.html
@@ -1,0 +1,1 @@
+<script src="js/ez-ajax-fetcher.js"></script>

--- a/mixins/ez-notifier.html
+++ b/mixins/ez-notifier.html
@@ -1,0 +1,1 @@
+<script src="js/ez-notifier.js"></script>

--- a/mixins/js/ez-ajax-fetcher.js
+++ b/mixins/js/ez-ajax-fetcher.js
@@ -1,0 +1,82 @@
+window.eZ = window.eZ || {};
+
+(function (ns) {
+    ns.mixins = ns.mixins || {};
+
+    /**
+     * Class expression mixin that adds support for fetching an URL or submitting
+     * forms with an AJAX request.
+     *
+     * @param {Function} superClass
+     * @return {Function}
+     */
+    ns.mixins.AjaxFetcher = function (superClass) {
+        return class AjaxFetcher extends superClass {
+            constructor() {
+                super();
+                this._trackFormButton();
+            }
+
+            /**
+             * Makes sure a reference to the submit button used to submit a form
+             * is stored in the property `_formButton`.
+             * This needed for multi buttons form when the POST request body
+             * should include which button was used.
+             * Note: ideally, it should be possible to use
+             * `document.activeElement` but unfortunatelly this does not work in
+             * Firefox and Safari for MacOS.
+             */
+            _trackFormButton() {
+                this.addEventListener('click', (e) => {
+                    if ( AjaxFetcher._isSubmitButton(e.target) ) {
+                        this._formButton = e.target;
+                    } else {
+                        delete this._formButton;
+                    }
+                });
+            }
+
+            /**
+             * Runs an AJAX request for the `update` parameter with optionally
+             * some `customHeaders`.
+             *
+             * @param {String|HTMLFormElement} update an URL or an form to
+             * submit
+             * @param {Object} [customHeaders = {}]
+             * @return {Promise}
+             */
+            _fetch(update, customHeaders = {}) {
+                const fetchOptions = {
+                    credentials: 'same-origin',
+                    headers: new Headers(customHeaders),
+                    redirect: 'follow',
+                };
+                let url = update;
+
+                if ( update instanceof HTMLFormElement ) {
+                    const data = new FormData(update);
+
+                    url = update.action;
+                    fetchOptions.method = update.method;
+                    if ( this._formButton ) { // TODO check if button is inside the submitted form?
+                        data.append(this._formButton.name, this._formButton.value);
+                    }
+                    fetchOptions.body = data;
+                }
+
+                return fetch(url, fetchOptions);
+            }
+
+            /**
+             * Checks whether the given `element` is a form submit button.
+             *
+             * @param {HTMLElement} element
+             * @static
+             * @return {Boolean}
+             */
+            static _isSubmitButton(element) {
+                return element && element.matches('form input[type="submit"], form button, form input[type="image"]');
+            }
+        };
+    };
+})(window.eZ);

--- a/mixins/js/ez-ajax-fetcher.js
+++ b/mixins/js/ez-ajax-fetcher.js
@@ -7,9 +7,9 @@ window.eZ = window.eZ || {};
      * Class expression mixin that adds support for fetching an URL or submitting
      * forms with an AJAX request.
      *
-     * The resulting class relies on the `fetch` which is not supported by
-     * Safari 10.0. So for the resulting component to work in this browser, the
-     * page should include a polyfill for this standard API.
+     * The resulting class relies on the `fetch` function which is not supported
+     * by Safari 10.0. So for the resulting component to work in this browser,
+     * the page should include a polyfill for this standard API.
      *
      * @param {Function} superClass
      * @return {Function}
@@ -62,7 +62,7 @@ window.eZ = window.eZ || {};
 
                     url = update.action;
                     fetchOptions.method = update.method;
-                    if ( this._formButton ) { // TODO check if button is inside the submitted form?
+                    if ( this._formButton ) {
                         data.append(this._formButton.name, this._formButton.value);
                     }
                     fetchOptions.body = data;

--- a/mixins/js/ez-ajax-fetcher.js
+++ b/mixins/js/ez-ajax-fetcher.js
@@ -7,6 +7,10 @@ window.eZ = window.eZ || {};
      * Class expression mixin that adds support for fetching an URL or submitting
      * forms with an AJAX request.
      *
+     * The resulting class relies on the `fetch` which is not supported by
+     * Safari 10.0. So for the resulting component to work in this browser, the
+     * page should include a polyfill for this standard API.
+     *
      * @param {Function} superClass
      * @return {Function}
      */

--- a/mixins/js/ez-notifier.js
+++ b/mixins/js/ez-notifier.js
@@ -1,0 +1,33 @@
+window.eZ = window.eZ || {};
+
+(function (ns) {
+    ns.mixins = ns.mixins || {};
+
+    /**
+     * Mixins tabs notification support into a class `superClass`. The resulting
+     * class has  a`notify()` method to issue notification to the user.
+     *
+     * @param {Function} superClass
+     * @return {Function}
+     */
+    ns.mixins.Notifier = function (superClass) {
+        return class extends superClass {
+            /**
+             * Dispatches the `ez:notify` event with the given `notification`
+             * object. This object can have the properties recognized by the
+             * `ez-notification` custom element.
+             *
+             * @param {Object} notification
+             */
+            notify(notification) {
+                this.dispatchEvent(new CustomEvent('ez:notify', {
+                    bubbles: true,
+                    cancelable: true,
+                    detail: {
+                        notification: notification,
+                    },
+                }));
+            }
+        };
+    };
+})(window.eZ);

--- a/mixins/js/ez-tabs.js
+++ b/mixins/js/ez-tabs.js
@@ -125,6 +125,16 @@ window.eZ = window.eZ || {};
                     element.classList.remove(TAB_IS_SELECTED);
                 });
             }
+
+            /**
+             * Returns the label link for the given `panel` element.
+             *
+             * @param {HTMLElement} panel
+             * @return {HTMLElement}
+             */
+            _getLabelLink(panel) {
+                return this.querySelector(`[href="#${panel.id}"]`);
+            }
         };
     };
 })(window.eZ);

--- a/mixins/js/ez-tabs.js
+++ b/mixins/js/ez-tabs.js
@@ -17,6 +17,25 @@ window.eZ = window.eZ || {};
      *   </div>
      * </div>
      *
+     * When switching tab, the event `ez:tabChange` is dispatched. This event is
+     * configured to bubble and to be cancelable. It also carries the tab label
+     * element and the tab panel element that are going to be selected.
+     * This event can be used like:
+     *
+     * ```js
+     * document.addEventListener('ez:tabChange', function (e) {
+     *     // a new tab is about to be selected
+     *     // e.detail.label is the `.ez-tabs-label` element that is about to be
+     *     // selected
+     *     // e.detail.panel is the `.ez-tabs-panel` element that is about to be
+     *     // selected
+     *     if (whatEverReason) {
+     *         // prevent the active tab to be changed
+     *         e.preventDefault();
+     *     }
+     * });
+     * ```
+     *
      * Among others standard APIs, this component relies on `Element.closest`.
      * `Element.closest` is not available in Edge 14. So for this component to
      * work in this browser, the page should include a polyfill for this
@@ -39,28 +58,59 @@ window.eZ = window.eZ || {};
              * another by clicking on tabs label.
              */
             _setupTabs() {
-                this.addEventListener('click', (e) => {
-                    const label = e.target.closest('.ez-tabs-label');
-
-                    if ( label ) {
-                        e.preventDefault();
-                        this._changeTab(e.target.getAttribute('href'), label);
-                    }
-                });
+                this.addEventListener('click', this._processTabChange.bind(this));
             }
 
             /**
-             * Changes tab so that the tab panel corresponding to `panelSelector`
-             * becomes visible and `tabsLabel` element is visually selected.
+             * Processes the tab change. It's a click event handler. This
+             * includes dispatching the `ez:tabChange` event. If it's not
+             * prevented, a new tab is selected.
              *
-             * @param {String} panelSelector
+             * @param {Event} e
+             */
+            _processTabChange(e) {
+                const label = e.target.closest('.ez-tabs-label');
+
+                if ( label ) {
+                    const panel = this.querySelector(e.target.getAttribute('href'));
+
+                    e.preventDefault();
+                    if ( this._dispatchTabChange(label, panel) ) {
+                        this._changeTab(panel, label);
+                    }
+                }
+            }
+
+            /**
+             * Dispatches the `ez:tabChange` event.
+             *
+             * @param {HTMLElement} label
+             * @param {HTMLElement} panel
+             * @return {Boolean} whether the event was prevented
+             */
+            _dispatchTabChange(label, panel) {
+                return this.dispatchEvent(new CustomEvent('ez:tabChange', {
+                    detail: {
+                        label: label,
+                        panel: panel,
+                    },
+                    bubbles: true,
+                    cancelable: true,
+                }));
+            }
+
+            /**
+             * Changes tab so that the tab `panel` element becomes visible and
+             * `tabsLabel` element is visually selected.
+             *
+             * @param {HTMLElement} panel
              * @param {HTMLElement} tabsLabel
              */
-            _changeTab(panelSelector, tabsLabel) {
+            _changeTab(panel, tabsLabel) {
                 this._unselectTab();
 
                 tabsLabel.classList.add(TAB_IS_SELECTED);
-                this.querySelector(panelSelector).classList.add(TAB_IS_SELECTED);
+                panel.classList.add(TAB_IS_SELECTED);
             }
 
             /**

--- a/mixins/js/ez-tabs.js
+++ b/mixins/js/ez-tabs.js
@@ -1,6 +1,8 @@
 window.eZ = window.eZ || {};
 
 (function (ns) {
+    ns.mixins = ns.mixins || {};
+
     /**
      * Mixins tabs support into a class extending `superClass`. The resulting
      * class expects the following HTML markup for tabs to work and to be styled
@@ -44,7 +46,7 @@ window.eZ = window.eZ || {};
      * @param {Function} superClass
      * @return {Function}
      */
-    ns.TabsMixin = function (superClass) {
+    ns.mixins.Tabs = function (superClass) {
         const TAB_IS_SELECTED = 'is-tab-selected';
 
         return class extends superClass {

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
   },
   "scripts": {
     "test": "npm run test-local",
-    "test-local": "./node_modules/.bin/polymer test --skip-plugin sauce",
-    "test-sauce": "./node_modules/.bin/polymer test --skip-plugin local",
+    "test-local": "./node_modules/.bin/polymer test --skip-plugin sauce --expanded",
+    "test-sauce": "./node_modules/.bin/polymer test --skip-plugin local --expanded",
     "serve": "./node_modules/.bin/polymer serve",
     "lint": "./node_modules/.bin/eslint js test/js"
   },

--- a/test/ez-asynchronous-block.html
+++ b/test/ez-asynchronous-block.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
+
+        <title>ez-asynchronous-block test</title>
+
+        <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+        <script src="../../fetch/fetch.js"></script><!-- for Safari 10.0 -->
+        <script src="../../web-component-tester/browser.js"></script>
+
+        <link rel="import" href="../ez-asynchronous-block.html">
+    </head>
+    <body>
+
+        <test-fixture id="BasicTestFixture">
+            <template>
+                <ez-asynchronous-block url="/test/responses/asynchronous-block.html"></ez-asynchronous-block>
+            </template>
+        </test-fixture>
+
+        <script src="js/ez-asynchronous-block.js"></script>
+    </body>
+</html>

--- a/test/ez-asynchronous-block.html
+++ b/test/ez-asynchronous-block.html
@@ -20,6 +20,12 @@
             </template>
         </test-fixture>
 
+        <test-fixture id="FormTestFixture">
+            <template>
+                <ez-asynchronous-block><form method="post" action="not-used-in-test"></form></ez-asynchronous-block>
+            </template>
+        </test-fixture>
+
         <script src="js/ez-asynchronous-block.js"></script>
     </body>
 </html>

--- a/test/ez-asynchronous-block.html
+++ b/test/ez-asynchronous-block.html
@@ -7,6 +7,7 @@
         <title>ez-asynchronous-block test</title>
 
         <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+        <script src="../../element-matches/closest.js"></script><!-- for Edge 14 -->
         <script src="../../fetch/fetch.js"></script><!-- for Safari 10.0 -->
         <script src="../../web-component-tester/browser.js"></script>
 
@@ -23,6 +24,18 @@
         <test-fixture id="FormTestFixture">
             <template>
                 <ez-asynchronous-block><form method="post" action="not-used-in-test"></form></ez-asynchronous-block>
+            </template>
+        </test-fixture>
+
+        <test-fixture id="LocalNavigationTestFixture">
+            <template>
+                <ez-asynchronous-block>
+                    <a href="/test/responses/asynchronous-block.html" class="local1 ez-js-local-navigation">Local navigation</a>
+                    <a href="/test/responses/asynchronous-block.html" class="normal">Normal navigation</a>
+                    <div class="ez-js-local-navigation">
+                        <a href="/test/responses/asynchronous-block.html" class="local2">Local navigation again</a>
+                    </div>
+                </ez-asynchronous-block>
             </template>
         </test-fixture>
 

--- a/test/ez-content-view.html
+++ b/test/ez-content-view.html
@@ -20,6 +20,7 @@
                     <ul class="ez-tabs-list">
                         <li class="ez-tabs-label is-tab-selected"><a href="#tab1">Tab 1</a></li>
                         <li class="ez-tabs-label"><a href="#tab2" class="tab-link">Tab 2</a></li>
+                        <li class="ez-tabs-label"><a href="#async-tab" class="async-tab-link">Async tab</a></li>
                     </ul>
                     <div class="ez-tabs-panels">
                         <div class="ez-tabs-panel is-tab-selected" id="tab1">
@@ -29,6 +30,7 @@
                         <div class="ez-tabs-panel" id="tab2">
                             Some other content
                         </div>
+                        <ez-asynchronous-block id="async-tab"></ez-asynchronous-block>
                     </div>
                 </ez-content-view>
             </template>
@@ -37,5 +39,6 @@
         <script src="js/ez-content-view.js"></script>
         <script src="js/ez-server-side-content.js"></script>
         <script src="mixins/js/ez-tabs.js"></script>
+        <script src="mixins/js/ez-notifier.js"></script>
     </body>
 </html>

--- a/test/ez-content-view.html
+++ b/test/ez-content-view.html
@@ -19,7 +19,7 @@
                 <ez-content-view>
                     <ul class="ez-tabs-list">
                         <li class="ez-tabs-label is-tab-selected"><a href="#tab1">Tab 1</a></li>
-                        <li class="ez-tabs-label"><a href="#tab2" class="tab-label">Tab 2</a></li>
+                        <li class="ez-tabs-label"><a href="#tab2" class="tab-link">Tab 2</a></li>
                     </ul>
                     <div class="ez-tabs-panels">
                         <div class="ez-tabs-panel is-tab-selected" id="tab1">

--- a/test/ez-server-side-content.html
+++ b/test/ez-server-side-content.html
@@ -19,7 +19,7 @@
                 <ez-server-side-content>
                     <ul class="ez-tabs-list">
                         <li class="ez-tabs-label is-tab-selected"><a href="#tab1">Tab 1</a></li>
-                        <li class="ez-tabs-label"><a href="#tab2" class="tab-label">Tab 2</a></li>
+                        <li class="ez-tabs-label"><a href="#tab2" class="tab-link">Tab 2</a></li>
                     </ul>
                     <div class="ez-tabs-panels">
                         <div class="ez-tabs-panel is-tab-selected" id="tab1">

--- a/test/js/ez-asynchronous-block.js
+++ b/test/js/ez-asynchronous-block.js
@@ -1,9 +1,10 @@
 describe('ez-asynchronous-block', function() {
-    let element, elementForm;
+    let element, elementForm, elementNavigation;
 
     beforeEach(function () {
         element = fixture('BasicTestFixture');
         elementForm = fixture('FormTestFixture');
+        elementNavigation = fixture('LocalNavigationTestFixture');
     });
 
     it('should be defined', function () {
@@ -137,6 +138,47 @@ describe('ez-asynchronous-block', function() {
                 element.url = 'http://ihopeitwillneverexists.test';
                 testBubble(element, 'ez:asynchronousBlock:error', done);
             });
+        });
+    });
+
+    describe('local navigation', function () {
+        let click;
+
+        beforeEach(function () {
+            click = new CustomEvent('click', {
+                bubbles: true,
+                cancelable: true,
+            });
+            sinon.spy(click, 'stopPropagation');
+        });
+
+        it('should ignore normal links', function () {
+            elementNavigation.querySelector('.normal').dispatchEvent(click);
+
+            assert.isFalse(click.defaultPrevented);
+            assert.isFalse(click.stopPropagation.called);
+        });
+
+        function testLocalNavigation(linkSelector, done) {
+            const assertNavigation = function () {
+                elementNavigation.removeEventListener('ez:asynchronousBlock:updated', assertNavigation);
+
+                assert.isTrue(click.defaultPrevented);
+                assert.isTrue(click.stopPropagation.called);
+                assert.isNotNull(elementNavigation.querySelector('.updated'));
+                done();
+            };
+
+            elementNavigation.addEventListener('ez:asynchronousBlock:updated', assertNavigation);
+            elementNavigation.querySelector(linkSelector).dispatchEvent(click);
+        }
+
+        it('should follow local navigation links', function (done) {
+            testLocalNavigation('.local1', done);
+        });
+
+        it('should follow links in local navigation block', function (done) {
+            testLocalNavigation('.local2', done);
         });
     });
 

--- a/test/js/ez-asynchronous-block.js
+++ b/test/js/ez-asynchronous-block.js
@@ -153,10 +153,26 @@ describe('ez-asynchronous-block', function() {
         });
 
         it('should ignore normal links', function () {
+            // this test is a bit complicated because we need to prevent the
+            // click event at the document level to prevent Edge/Safari from browsing
+            // so preventDefault() will be called in the test but we want to
+            // check that's it not called, that's why `preventDefaultCalled`
+            // local variable was introduced to differentiate those 2
+            // situations.
+            let preventDefaultCalled = false;
+            const prevent = function(e) {
+                preventDefaultCalled = e.preventDefault.called;
+                e.preventDefault.restore();
+                e.preventDefault();
+            };
+
+            sinon.spy(click, 'preventDefault');
+            document.addEventListener('click', prevent);
             elementNavigation.querySelector('.normal').dispatchEvent(click);
 
-            assert.isFalse(click.defaultPrevented);
+            assert.isFalse(preventDefaultCalled);
             assert.isFalse(click.stopPropagation.called);
+            document.removeEventListener('click', prevent);
         });
 
         function testLocalNavigation(linkSelector, done) {

--- a/test/js/ez-asynchronous-block.js
+++ b/test/js/ez-asynchronous-block.js
@@ -1,0 +1,125 @@
+describe('ez-asynchronous-block', function() {
+    let element;
+
+    beforeEach(function () {
+        element = fixture('BasicTestFixture');
+    });
+
+    it('should be defined', function () {
+        assert.equal(
+            window.customElements.get('ez-asynchronous-block'),
+            element.constructor
+        );
+    });
+
+    describe('properties', function () {
+        describe('`loading`', function () {
+            it('should default to false', function () {
+                assert.isFalse(element.loading);
+            });
+
+            it('should be reflected to an attribute', function () {
+                element.loading = true;
+                assert.isTrue(element.hasAttribute('loading'));
+            });
+
+            it('should be set to true when loading', function () {
+                element.load();
+                assert.isTrue(element.loading);
+            });
+        });
+
+        describe('`loaded`', function () {
+            it('should default to false', function () {
+                assert.isFalse(element.loaded);
+            });
+
+            it('should be set after a successful loading', function (done) {
+                element.addEventListener('ez:asynchronousBlock:updated', function () {
+                    assert.isTrue(element.loaded);
+                    done();
+                });
+                element.load();
+            });
+        });
+
+        describe('`url`', function () {
+            it('should be defined', function () {
+                assert.equal(
+                    element.url,
+                    element.getAttribute('url')
+                );
+            });
+        });
+    });
+
+    describe('load()', function () {
+        beforeEach(function () {
+            sinon.spy(window, 'fetch');
+        });
+
+        afterEach(function () {
+            fetch.restore();
+        });
+
+        it('should request the `url`', function () {
+            element.load();
+
+            assert.isTrue(fetch.calledOnce);
+            assert.isTrue(fetch.alwaysCalledWith(element.url));
+        });
+
+        it('should update the content', function (done) {
+            element.addEventListener('ez:asynchronousBlock:updated', function () {
+                assert.isNotNull(element.querySelector('.updated'));
+                done();
+            });
+            element.load();
+        });
+
+        it('should handle errors', function (done) {
+            element.addEventListener('ez:asynchronousBlock:error', function (e) {
+                // this should test instanceof Error instead
+                // but in Edge with the fetch polyfill it's not an Error object!?
+                assert.isDefined(
+                    e.detail.error,
+                    'The error should be provided in the event'
+                );
+                assert.isFalse(
+                    element.loading,
+                    '`loading` should be set to false'
+                );
+                assert.isFalse(
+                    element.loaded,
+                    '`loaded` should be set to false'
+                );
+                done();
+            });
+            element.url = 'http://ihopeitwillneverexists.test';
+            element.load();
+        });
+
+        function testBubble(element, eventName, done) {
+            const assertBubble = function () {
+                document.removeEventListener(eventName, assertBubble);
+                done();
+            };
+
+            document.addEventListener(eventName, assertBubble);
+            element.load();
+        }
+
+        describe('`ez:asynchronousBlock:updated`', function () {
+            it('should bubble', function (done) {
+                testBubble(element, 'ez:asynchronousBlock:updated', done);
+            });
+        });
+
+        describe('`ez:asynchronousBlock:error', function () {
+            it('should bubble', function (done) {
+                element.url = 'http://ihopeitwillneverexists.test';
+                testBubble(element, 'ez:asynchronousBlock:error', done);
+            });
+        });
+    });
+});

--- a/test/js/ez-asynchronous-block.js
+++ b/test/js/ez-asynchronous-block.js
@@ -77,14 +77,15 @@ describe('ez-asynchronous-block', function() {
             element.load();
         });
 
-        it('should handle errors', function (done) {
-            element.addEventListener('ez:asynchronousBlock:error', function (e) {
+        describe('network error handling', function () {
+            function assertError(error, element) {
                 // this should test instanceof Error instead
                 // but in Edge with the fetch polyfill it's not an Error object!?
                 assert.isDefined(
-                    e.detail.error,
+                    error,
                     'The error should be provided in the event'
                 );
+
                 assert.isFalse(
                     element.loading,
                     '`loading` should be set to false'
@@ -93,10 +94,25 @@ describe('ez-asynchronous-block', function() {
                     element.loaded,
                     '`loaded` should be set to false'
                 );
-                done();
+            }
+
+            it('should handle connection errors', function (done) {
+                element.addEventListener('ez:asynchronousBlock:error', function (e) {
+                    assertError(e.detail.error, element);
+                    done();
+                });
+                element.url = 'http://ihopeitwillneverexists.test';
+                element.load();
             });
-            element.url = 'http://ihopeitwillneverexists.test';
-            element.load();
+
+            it('should handle 40X errors', function (done) {
+                element.addEventListener('ez:asynchronousBlock:error', function (e) {
+                    assertError(e.detail.error, element);
+                    done();
+                });
+                element.url = 'test/does/not/exist';
+                element.load();
+            });
         });
 
         function testBubble(element, eventName, done) {

--- a/test/js/ez-content-view.js
+++ b/test/js/ez-content-view.js
@@ -11,4 +11,60 @@ describe('ez-content-view', function() {
             element.constructor
         );
     });
+
+    describe('asynchronous tab', function () {
+        let panel;
+
+        beforeEach(function () {
+            panel = element.querySelector('ez-asynchronous-block');
+            sinon.stub(panel, 'load', function () {});
+        });
+
+        afterEach(function () {
+            panel.load.restore();
+        });
+
+        function changeTab(element) {
+            element.querySelector('.async-tab-link').dispatchEvent(new CustomEvent('click', {
+                bubbles: true,
+                cancelable: true,
+            }));
+        }
+
+        it('should load the tab', function () {
+            changeTab(element);
+            assert.isTrue(panel.load.calledOnce);
+        });
+
+        it('should not reload a loaded tab', function () {
+            panel.loaded = true;
+            changeTab(element);
+            assert.isFalse(panel.load.called);
+        });
+
+        it('should notify loading error', function () {
+            const errorEvent = new CustomEvent('ez:asynchronousBlock:error', {
+                bubbles: true,
+            });
+            let notification = false;
+
+            sinon.spy(errorEvent, 'stopPropagation');
+
+            element.addEventListener('ez:notify', function (e) {
+                notification = true;
+
+                assert.equal(
+                    e.detail.notification.type, 'error',
+                    'An error notifcation should have been generated'
+                );
+            });
+            panel.dispatchEvent(errorEvent);
+
+            assert.isTrue(notification);
+            assert.isTrue(
+                errorEvent.stopPropagation.called,
+                'The event should have been stopped'
+            );
+        });
+    });
 });

--- a/test/js/ez-platform-ui-app.js
+++ b/test/js/ez-platform-ui-app.js
@@ -127,10 +127,13 @@ describe('ez-platform-ui-app', function() {
                 });
 
                 it('should be unset after the update', function (done) {
-                    element.addEventListener('ez:app:updated', function () {
+                    const check = function () {
+                        element.removeEventListener('ez:app:updated', check);
                         assert.notOk(element.updating);
                         done();
-                    });
+                    };
+
+                    element.addEventListener('ez:app:updated', check);
                     element.url = urlEmptyUpdate;
                 });
 
@@ -769,10 +772,10 @@ describe('ez-platform-ui-app', function() {
 
     describe('history', function () {
         it('should push an history entry', function (done) {
-            element.addEventListener('ez:app:updated', function () {
-                assert.equal(
-                    urlEmptyUpdate,
-                    history.state.url
+            const check = function () {
+                element.removeEventListener('ez:app:updated', check);
+                assert.isTrue(
+                    history.state.url.endsWith(urlEmptyUpdate)
                 );
                 assert.ok(
                     history.state.enhanced,
@@ -780,7 +783,9 @@ describe('ez-platform-ui-app', function() {
                 );
 
                 done();
-            });
+            };
+
+            element.addEventListener('ez:app:updated', check);
             element.url = urlEmptyUpdate;
         });
 

--- a/test/js/ez-platform-ui-app.js
+++ b/test/js/ez-platform-ui-app.js
@@ -215,6 +215,24 @@ describe('ez-platform-ui-app', function() {
                 assert.strictEqual(0, notifElement.querySelector('ez-notification').timeout);
             });
 
+            it('should set `timeout` for `error` notification', function () {
+                const notification = {
+                    type: 'error',
+                };
+
+                notifElement.notifications = [notification];
+                assert.strictEqual(0, notifElement.querySelector('ez-notification').timeout);
+            });
+
+            it('should set `timeout` for other than `error` notification', function () {
+                const notification = {
+                    type: 'noterror',
+                };
+
+                notifElement.notifications = [notification];
+                assert.strictEqual(10, notifElement.querySelector('ez-notification').timeout);
+            });
+
             it('should convert notification `copyable` to a boolean', function () {
                 const notification = {
                     type: 'error',
@@ -225,6 +243,23 @@ describe('ez-platform-ui-app', function() {
 
                 notifElement.notifications = [notification];
                 assert.isTrue(notifElement.querySelector('ez-notification').copyable);
+            });
+
+            describe('`ez:notify` event', function () {
+                it('should set a notification', function () {
+                    const notification = {
+                        type: 'error',
+                    };
+
+                    notifElement.dispatchEvent(new CustomEvent('ez:notify', {
+                        detail: {
+                            notification: notification,
+                        },
+                    }));
+                    assert.strictEqual(
+                        notification, notifElement.notifications[0]
+                    );
+                });
             });
         });
     });

--- a/test/mixins/ez-notifier.html
+++ b/test/mixins/ez-notifier.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
+
+        <title>ez-notifier test</title>
+
+        <script src="../../../webcomponentsjs/webcomponents-lite.js"></script>
+        <script src="../../../web-component-tester/browser.js"></script>
+
+        <link rel="import" href="../../../polymer/polymer-element.html">
+        <link rel="import" href="../../mixins/ez-notifier.html">
+        <script>
+        window.addEventListener('WebComponentsReady', function () {
+            class TestElement extends eZ.mixins.Notifier(Polymer.Element) {
+                static get is() {
+                    return 'ez-test-notifier';
+                }
+            }
+
+            window.customElements.define(TestElement.is, TestElement);
+        });
+        </script>
+    </head>
+    <body>
+
+        <test-fixture id="BasicTestFixture">
+            <template>
+                <ez-test-notifier></ez-test-notifier>
+            </template>
+        </test-fixture>
+
+        <script src="js/ez-notifier.js"></script>
+    </body>
+</html>

--- a/test/mixins/ez-tabs.html
+++ b/test/mixins/ez-tabs.html
@@ -14,7 +14,7 @@
         <link rel="import" href="../../mixins/ez-tabs.html">
         <script>
         window.addEventListener('WebComponentsReady', function () {
-            class TestElement extends eZ.TabsMixin(Polymer.Element) {
+            class TestElement extends eZ.mixins.Tabs(Polymer.Element) {
                 static get is() {
                     return 'ez-test-tabs';
                 }

--- a/test/mixins/ez-tabs.html
+++ b/test/mixins/ez-tabs.html
@@ -31,7 +31,7 @@
                 <ez-test-tabs>
                     <ul class="ez-tabs-list">
                         <li class="ez-tabs-label is-tab-selected"><a href="#tab1">Tab 1</a></li>
-                        <li class="ez-tabs-label"><a href="#tab2" class="tab-label">Tab 2</a></li>
+                        <li class="ez-tabs-label"><a href="#tab2" class="tab-link">Tab 2</a></li>
                     </ul>
                     <div class="ez-tabs-panels">
                         <div class="ez-tabs-panel is-tab-selected" id="tab1">

--- a/test/mixins/js/ez-notifier.js
+++ b/test/mixins/js/ez-notifier.js
@@ -1,0 +1,45 @@
+describe('ez-notifier', function () {
+    let element;
+
+    beforeEach(function () {
+        element = fixture('BasicTestFixture');
+    });
+
+    it('should define `eZ.mixins.notifier`', function () {
+        assert.isFunction(window.eZ.mixins.Notifier);
+    });
+
+    describe('notify()', function () {
+        describe('`ez:notify` event', function () {
+            const notification = {};
+
+            it('should be dispatched', function () {
+                let dispatched = false;
+
+                element.addEventListener('ez:notify', function (e) {
+                    dispatched = true;
+                    assert.strictEqual(
+                        e.detail.notification,
+                        notification,
+                        'The event detail should contain the notification'
+                    );
+                });
+                element.notify(notification);
+
+                assert.isTrue(dispatched);
+            });
+
+            it('should bubble', function () {
+                let bubble = false;
+                const assertBubble = function () {
+                    document.removeEventListener('ez:notify', assertBubble);
+                    bubble = true;
+                };
+
+                document.addEventListener('ez:notify', assertBubble);
+                element.notify(notification);
+                assert.isTrue(bubble);
+            });
+        });
+    });
+});

--- a/test/mixins/js/ez-tabs.js
+++ b/test/mixins/js/ez-tabs.js
@@ -5,8 +5,8 @@ describe('ez-tabs', function () {
         element = fixture('BasicTestFixture');
     });
 
-    it('should define the eZ.TabsMixin', function () {
-        assert.isFunction(window.eZ.TabsMixin);
+    it('should define `eZ.mixins.Tabs`', function () {
+        assert.isFunction(window.eZ.mixins.Tabs);
     });
 
     describe('swich tab', function () {

--- a/test/mixins/js/ez-tabs.js
+++ b/test/mixins/js/ez-tabs.js
@@ -10,17 +10,24 @@ describe('ez-tabs', function () {
     });
 
     describe('swich tab', function () {
+        let link, label, panel;
+
         function simulateClick(element) {
             element.dispatchEvent(new CustomEvent('click', {
                 bubbles: true,
             }));
         }
 
+        beforeEach(function () {
+            link = element.querySelector('.tab-link');
+            label = link.parentNode;
+            panel = element.querySelector(link.getAttribute('href'));
+        });
+
         it('should change tab', function () {
-            const label = element.querySelector('.tab-label');
             const selected = element.querySelector('.is-tab-selected');
 
-            simulateClick(label);
+            simulateClick(link);
 
             Array.prototype.forEach.call(selected, function (el) {
                 assert.isFalse(
@@ -29,11 +36,11 @@ describe('ez-tabs', function () {
                 );
             });
             assert.isTrue(
-                label.parentNode.classList.contains('is-tab-selected'),
+                label.classList.contains('is-tab-selected'),
                 'A new tab should be selected'
             );
             assert.isTrue(
-                element.querySelector(label.getAttribute('href')).classList.contains('is-tab-selected'),
+                panel.classList.contains('is-tab-selected'),
                 'A new panel should be visible'
             );
         });
@@ -46,6 +53,56 @@ describe('ez-tabs', function () {
                 initialContent,
                 element.innerHTML
             );
+        });
+
+        describe('`ez:tabChange` event', function () {
+            it('should be dispatched', function () {
+                let tabChangeEvent = false;
+
+                element.addEventListener('ez:tabChange', function (e) {
+                    tabChangeEvent = true;
+
+                    assert.strictEqual(
+                        label, e.detail.label,
+                        'The tab label should be provided in the event detail'
+                    );
+                    assert.strictEqual(
+                        panel, e.detail.panel,
+                        'The tab panel should be provided in the event detail'
+                    );
+                });
+                simulateClick(link);
+
+                assert.isTrue(tabChangeEvent);
+            });
+
+            it('should bubble', function () {
+                let bubble = false;
+                const assertBubble = function () {
+                    bubble = true;
+                    document.removeEventListener('ez:tabChange', assertBubble);
+                };
+
+                document.addEventListener('ez:tabChange', assertBubble);
+                simulateClick(link);
+                assert.isTrue(bubble);
+            });
+
+            it('should be preventable', function () {
+                element.addEventListener('ez:tabChange', function (e) {
+                    e.preventDefault();
+                });
+                simulateClick(link);
+
+                assert.isFalse(
+                    label.classList.contains('is-tab-selected'),
+                    'A new tab should not be selected'
+                );
+                assert.isFalse(
+                    panel.classList.contains('is-tab-selected'),
+                    'A new panel should not be visible'
+                );
+            });
         });
     });
 });

--- a/test/responses/asynchronous-block.html
+++ b/test/responses/asynchronous-block.html
@@ -1,0 +1,1 @@
+<p class="updated">Foo Fighters - Time like theses</p>

--- a/wct.conf.json
+++ b/wct.conf.json
@@ -13,19 +13,19 @@
             }, {
                 "browserName": "firefox",
                 "platform": "macOS 10.12",
-                "version": "52.0"
+                "version": "latest"
             }, {
                 "browserName": "firefox",
                 "platform": "Windows 10",
-                "version": "52.0"
+                "version": "latest"
             }, {
                 "browserName": "chrome",
                 "platform": "macOS 10.12",
-                "version": "57.0"
+                "version": "latest"
             }, {
                 "browserName": "chrome",
                 "platform": "Windows 10",
-                "version": "57.0"
+                "version": "latest"
             }]
         }
     }

--- a/wct.conf.json
+++ b/wct.conf.json
@@ -5,6 +5,10 @@
             "browsers": [{
                 "browserName": "MicrosoftEdge",
                 "platform": "Windows 10",
+                "version": "15.15063"
+            }, {
+                "browserName": "MicrosoftEdge",
+                "platform": "Windows 10",
                 "version": "14.14393"
             }, {
                 "browserName": "safari",


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-27569
See https://github.com/ezsystems/hybrid-platform-ui/pull/48 for use in Twig template

# Description

This patch adds the system to asynchronously load some tabs in the Content view. The heart of that is the `<ez-asynchronous-block>` custom element. This custom element is able to load an URL and to use the response content to set its own content. In addition to that, the tab system now has a `ez:tabChange` event which lets the `<ez-content-view>` custom element to load the asynchronously loaded tab panel.

As shown in the following screencast, tabs loading error are handled with a simple error notification.

[![](https://img.youtube.com/vi/YgiORV0rA8E/0.jpg)](http://www.youtube.com/watch?v=YgiORV0rA8E "Click to play on Youtube.com")

## Tasks

* [x] Improve tabs system to dispatch an event when changing tab
* [x] Add `<ez-asynchronous-block>` custom element
* [x] Change `<ez-platform-ui-app>` to listen for `ez:notify` and display notifications
* [x] Load content view tabs when becoming selected (~~blocked until https://github.com/ezsystems/hybrid-platform-ui-core-components/pull/24 is merged~~)

# Test

manual  test and unit tests