### PR TITLE
EZP-27571: Implement Content view tab local update and navigation

### DIFF
--- a/demo/asynchronous-load-navigation.html
+++ b/demo/asynchronous-load-navigation.html
@@ -1,0 +1,4 @@
+<p>Local to the block navigation happened!</p>
+<div class="ez-js-local-navigation">
+    <p><a href="asynchronous-load.html">Return to previous state</a></p>
+</div>

--- a/demo/asynchronous-load.html
+++ b/demo/asynchronous-load.html
@@ -1,2 +1,3 @@
 <p>Hey, I was loaded <strong>asynchronously</strong></p>
 <p><em>Cool</em>, isn't it?</p>
+<p><a href="asynchronous-load-navigation.html" class="ez-js-local-navigation">Here is a link that should update the block</a></p>

--- a/ez-asynchronous-block.html
+++ b/ez-asynchronous-block.html
@@ -1,4 +1,5 @@
 <link rel="import" href="../polymer/polymer-element.html">
+<link rel="import" href="mixins/ez-ajax-fetcher.html">
 
 <style>
     ez-asynchronous-block {

--- a/ez-platform-ui-app.html
+++ b/ez-platform-ui-app.html
@@ -1,4 +1,5 @@
 <link rel="import" href="../polymer/polymer-element.html">
+<link rel="import" href="mixins/ez-ajax-fetcher.html">
 <link rel="import" href="ez-notification.html">
 
 <style>

--- a/js/ez-asynchronous-block.js
+++ b/js/ez-asynchronous-block.js
@@ -27,9 +27,9 @@
      *   the block will be updated with the server response.
      *
      * Among others standard APIs, this component relies on `fetch` and
-     * `Element.closest`. `fetch` is not supported by Safari 10.0 and
-     * `Element.closest` is not available in Edge 14. So for this component to
-     * work in those browser, the page should include polyfills of those
+     * `Element.matches`. `fetch` is not supported by Safari 10.0 and
+     * `Element.matches` is not available in Edge 14. So for this component to
+     * work in those browsers, the page should include polyfills of those
      * standard API.
      *
      * @polymerElement
@@ -74,7 +74,7 @@
         }
 
         /**
-         * Adds a event listeners to implement the *local* navigation.
+         * Adds event listeners to implement the *local* navigation.
          * If a user clicks on a link with the class `ez-js-local-navigation` or
          * which is descendant of an element with that class, the Asynchronous
          * Block will do the corresponding AJAX request and updates itself with

--- a/js/ez-asynchronous-block.js
+++ b/js/ez-asynchronous-block.js
@@ -1,3 +1,4 @@
+/* global eZ */
 (function () {
     // FIXME: after https://jira.ez.no/browse/EZP-27582
     // remove that function!
@@ -25,7 +26,7 @@
      * @polymerElement
      * @demo demo/ez-asynchronous-block.html
      */
-    class AsynchronousBlock extends Polymer.Element {
+    class AsynchronousBlock extends eZ.mixins.AjaxFetcher(Polymer.Element) {
         static get is() {
             return 'ez-asynchronous-block';
         }
@@ -64,15 +65,11 @@
          * `ez:asynchronousBlock:updated` event is dispatched.
          */
         load() {
-            const fetchOptions = {
-                credentials: 'same-origin',
-                // FIXME: after https://jira.ez.no/browse/EZP-27582
-                // this is where the custom Header should be set
-                redirect: 'follow',
-            };
-
             this.loading = true;
-            fetch(this.url, fetchOptions)
+            // FIXME: after https://jira.ez.no/browse/EZP-27582
+            // this._fetch should have a second parameter with the header
+            // so the server generates the HTML without the app layout
+            this._fetch(update)
                 .then((response) => {
                     if ( response.status >= 400 ) {
                         throw new Error();

--- a/js/ez-asynchronous-block.js
+++ b/js/ez-asynchronous-block.js
@@ -59,12 +59,33 @@
             };
         }
 
+        connectedCallback() {
+            super.connectedCallback();
+            this._setupFormHandling();
+        }
+
+        /**
+         * Adds a submit event listener so that forms are posted in AJAX by this
+         * component.
+         */
+        _setupFormHandling() {
+            this.addEventListener('submit', (e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                this.load(e.target);
+            });
+        }
+
         /**
          * Loads the Asynchronous Block content. If the loading is successful,
          * the `loaded` property is set to true and the
          * `ez:asynchronousBlock:updated` event is dispatched.
+         *
+         * @param {HTMLFormElement} [form]
          */
-        load() {
+        load(form) {
+            const update = form || this.url;
+
             this.loading = true;
             // FIXME: after https://jira.ez.no/browse/EZP-27582
             // this._fetch should have a second parameter with the header

--- a/mixins/ez-ajax-fetcher.html
+++ b/mixins/ez-ajax-fetcher.html
@@ -1,0 +1,1 @@
+<script src="js/ez-ajax-fetcher.js"></script>

--- a/mixins/js/ez-ajax-fetcher.js
+++ b/mixins/js/ez-ajax-fetcher.js
@@ -1,0 +1,82 @@
+window.eZ = window.eZ || {};
+
+(function (ns) {
+    ns.mixins = ns.mixins || {};
+
+    /**
+     * Class expression mixin that adds support for fetching an URL or submitting
+     * forms with an AJAX request.
+     *
+     * @param {Function} superClass
+     * @return {Function}
+     */
+    ns.mixins.AjaxFetcher = function (superClass) {
+        return class AjaxFetcher extends superClass {
+            constructor() {
+                super();
+                this._trackFormButton();
+            }
+
+            /**
+             * Makes sure a reference to the submit button used to submit a form
+             * is stored in the property `_formButton`.
+             * This needed for multi buttons form when the POST request body
+             * should include which button was used.
+             * Note: ideally, it should be possible to use
+             * `document.activeElement` but unfortunatelly this does not work in
+             * Firefox and Safari for MacOS.
+             */
+            _trackFormButton() {
+                this.addEventListener('click', (e) => {
+                    if ( AjaxFetcher._isSubmitButton(e.target) ) {
+                        this._formButton = e.target;
+                    } else {
+                        delete this._formButton;
+                    }
+                });
+            }
+
+            /**
+             * Runs an AJAX request for the `update` parameter with optionally
+             * some `customHeaders`.
+             *
+             * @param {String|HTMLFormElement} update an URL or an form to
+             * submit
+             * @param {Object} [customHeaders = {}]
+             * @return {Promise}
+             */
+            _fetch(update, customHeaders = {}) {
+                const fetchOptions = {
+                    credentials: 'same-origin',
+                    headers: new Headers(customHeaders),
+                    redirect: 'follow',
+                };
+                let url = update;
+
+                if ( update instanceof HTMLFormElement ) {
+                    const data = new FormData(update);
+
+                    url = update.action;
+                    fetchOptions.method = update.method;
+                    if ( this._formButton ) { // TODO check if button is inside the submitted form?
+                        data.append(this._formButton.name, this._formButton.value);
+                    }
+                    fetchOptions.body = data;
+                }
+
+                return fetch(url, fetchOptions);
+            }
+
+            /**
+             * Checks whether the given `element` is a form submit button.
+             *
+             * @param {HTMLElement} element
+             * @static
+             * @return {Boolean}
+             */
+            static _isSubmitButton(element) {
+                return element && element.matches('form input[type="submit"], form button, form input[type="image"]');
+            }
+        };
+    };
+})(window.eZ);

--- a/mixins/js/ez-ajax-fetcher.js
+++ b/mixins/js/ez-ajax-fetcher.js
@@ -7,9 +7,9 @@ window.eZ = window.eZ || {};
      * Class expression mixin that adds support for fetching an URL or submitting
      * forms with an AJAX request.
      *
-     * The resulting class relies on the `fetch` which is not supported by
-     * Safari 10.0. So for the resulting component to work in this browser, the
-     * page should include a polyfill for this standard API.
+     * The resulting class relies on the `fetch` function which is not supported
+     * by Safari 10.0. So for the resulting component to work in this browser,
+     * the page should include a polyfill for this standard API.
      *
      * @param {Function} superClass
      * @return {Function}
@@ -62,7 +62,7 @@ window.eZ = window.eZ || {};
 
                     url = update.action;
                     fetchOptions.method = update.method;
-                    if ( this._formButton ) { // TODO check if button is inside the submitted form?
+                    if ( this._formButton ) {
                         data.append(this._formButton.name, this._formButton.value);
                     }
                     fetchOptions.body = data;

--- a/mixins/js/ez-ajax-fetcher.js
+++ b/mixins/js/ez-ajax-fetcher.js
@@ -7,6 +7,10 @@ window.eZ = window.eZ || {};
      * Class expression mixin that adds support for fetching an URL or submitting
      * forms with an AJAX request.
      *
+     * The resulting class relies on the `fetch` which is not supported by
+     * Safari 10.0. So for the resulting component to work in this browser, the
+     * page should include a polyfill for this standard API.
+     *
      * @param {Function} superClass
      * @return {Function}
      */

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
   },
   "scripts": {
     "test": "npm run test-local",
-    "test-local": "./node_modules/.bin/polymer test --skip-plugin sauce",
-    "test-sauce": "./node_modules/.bin/polymer test --skip-plugin local",
+    "test-local": "./node_modules/.bin/polymer test --skip-plugin sauce --expanded",
+    "test-sauce": "./node_modules/.bin/polymer test --skip-plugin local --expanded",
     "serve": "./node_modules/.bin/polymer serve",
     "lint": "./node_modules/.bin/eslint js test/js"
   },

--- a/test/ez-asynchronous-block.html
+++ b/test/ez-asynchronous-block.html
@@ -20,6 +20,12 @@
             </template>
         </test-fixture>
 
+        <test-fixture id="FormTestFixture">
+            <template>
+                <ez-asynchronous-block><form method="post" action="not-used-in-test"></form></ez-asynchronous-block>
+            </template>
+        </test-fixture>
+
         <script src="js/ez-asynchronous-block.js"></script>
     </body>
 </html>

--- a/test/ez-asynchronous-block.html
+++ b/test/ez-asynchronous-block.html
@@ -7,6 +7,7 @@
         <title>ez-asynchronous-block test</title>
 
         <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+        <script src="../../element-matches/closest.js"></script><!-- for Edge 14 -->
         <script src="../../fetch/fetch.js"></script><!-- for Safari 10.0 -->
         <script src="../../web-component-tester/browser.js"></script>
 
@@ -23,6 +24,18 @@
         <test-fixture id="FormTestFixture">
             <template>
                 <ez-asynchronous-block><form method="post" action="not-used-in-test"></form></ez-asynchronous-block>
+            </template>
+        </test-fixture>
+
+        <test-fixture id="LocalNavigationTestFixture">
+            <template>
+                <ez-asynchronous-block>
+                    <a href="/test/responses/asynchronous-block.html" class="local1 ez-js-local-navigation">Local navigation</a>
+                    <a href="/test/responses/asynchronous-block.html" class="normal">Normal navigation</a>
+                    <div class="ez-js-local-navigation">
+                        <a href="/test/responses/asynchronous-block.html" class="local2">Local navigation again</a>
+                    </div>
+                </ez-asynchronous-block>
             </template>
         </test-fixture>
 

--- a/test/js/ez-asynchronous-block.js
+++ b/test/js/ez-asynchronous-block.js
@@ -1,9 +1,10 @@
 describe('ez-asynchronous-block', function() {
-    let element, elementForm;
+    let element, elementForm, elementNavigation;
 
     beforeEach(function () {
         element = fixture('BasicTestFixture');
         elementForm = fixture('FormTestFixture');
+        elementNavigation = fixture('LocalNavigationTestFixture');
     });
 
     it('should be defined', function () {
@@ -137,6 +138,47 @@ describe('ez-asynchronous-block', function() {
                 element.url = 'http://ihopeitwillneverexists.test';
                 testBubble(element, 'ez:asynchronousBlock:error', done);
             });
+        });
+    });
+
+    describe('local navigation', function () {
+        let click;
+
+        beforeEach(function () {
+            click = new CustomEvent('click', {
+                bubbles: true,
+                cancelable: true,
+            });
+            sinon.spy(click, 'stopPropagation');
+        });
+
+        it('should ignore normal links', function () {
+            elementNavigation.querySelector('.normal').dispatchEvent(click);
+
+            assert.isFalse(click.defaultPrevented);
+            assert.isFalse(click.stopPropagation.called);
+        });
+
+        function testLocalNavigation(linkSelector, done) {
+            const assertNavigation = function () {
+                elementNavigation.removeEventListener('ez:asynchronousBlock:updated', assertNavigation);
+
+                assert.isTrue(click.defaultPrevented);
+                assert.isTrue(click.stopPropagation.called);
+                assert.isNotNull(elementNavigation.querySelector('.updated'));
+                done();
+            };
+
+            elementNavigation.addEventListener('ez:asynchronousBlock:updated', assertNavigation);
+            elementNavigation.querySelector(linkSelector).dispatchEvent(click);
+        }
+
+        it('should follow local navigation links', function (done) {
+            testLocalNavigation('.local1', done);
+        });
+
+        it('should follow links in local navigation block', function (done) {
+            testLocalNavigation('.local2', done);
         });
     });
 

--- a/test/js/ez-asynchronous-block.js
+++ b/test/js/ez-asynchronous-block.js
@@ -153,10 +153,26 @@ describe('ez-asynchronous-block', function() {
         });
 
         it('should ignore normal links', function () {
+            // this test is a bit complicated because we need to prevent the
+            // click event at the document level to prevent Edge/Safari from browsing
+            // so preventDefault() will be called in the test but we want to
+            // check that's it not called, that's why `preventDefaultCalled`
+            // local variable was introduced to differentiate those 2
+            // situations.
+            let preventDefaultCalled = false;
+            const prevent = function(e) {
+                preventDefaultCalled = e.preventDefault.called;
+                e.preventDefault.restore();
+                e.preventDefault();
+            };
+
+            sinon.spy(click, 'preventDefault');
+            document.addEventListener('click', prevent);
             elementNavigation.querySelector('.normal').dispatchEvent(click);
 
-            assert.isFalse(click.defaultPrevented);
+            assert.isFalse(preventDefaultCalled);
             assert.isFalse(click.stopPropagation.called);
+            document.removeEventListener('click', prevent);
         });
 
         function testLocalNavigation(linkSelector, done) {

--- a/test/js/ez-platform-ui-app.js
+++ b/test/js/ez-platform-ui-app.js
@@ -127,10 +127,13 @@ describe('ez-platform-ui-app', function() {
                 });
 
                 it('should be unset after the update', function (done) {
-                    element.addEventListener('ez:app:updated', function () {
+                    const check = function () {
+                        element.removeEventListener('ez:app:updated', check);
                         assert.notOk(element.updating);
                         done();
-                    });
+                    };
+
+                    element.addEventListener('ez:app:updated', check);
                     element.url = urlEmptyUpdate;
                 });
 
@@ -769,10 +772,10 @@ describe('ez-platform-ui-app', function() {
 
     describe('history', function () {
         it('should push an history entry', function (done) {
-            element.addEventListener('ez:app:updated', function () {
-                assert.equal(
-                    urlEmptyUpdate,
-                    history.state.url
+            const check = function () {
+                element.removeEventListener('ez:app:updated', check);
+                assert.isTrue(
+                    history.state.url.endsWith(urlEmptyUpdate)
                 );
                 assert.ok(
                     history.state.enhanced,
@@ -780,7 +783,9 @@ describe('ez-platform-ui-app', function() {
                 );
 
                 done();
-            });
+            };
+
+            element.addEventListener('ez:app:updated', check);
             element.url = urlEmptyUpdate;
         });
 

--- a/wct.conf.json
+++ b/wct.conf.json
@@ -13,19 +13,19 @@
             }, {
                 "browserName": "firefox",
                 "platform": "macOS 10.12",
-                "version": "52.0"
+                "version": "latest"
             }, {
                 "browserName": "firefox",
                 "platform": "Windows 10",
-                "version": "52.0"
+                "version": "latest"
             }, {
                 "browserName": "chrome",
                 "platform": "macOS 10.12",
-                "version": "57.0"
+                "version": "latest"
             }, {
                 "browserName": "chrome",
                 "platform": "Windows 10",
-                "version": "57.0"
+                "version": "latest"
             }]
         }
     }

--- a/wct.conf.json
+++ b/wct.conf.json
@@ -5,6 +5,10 @@
             "browsers": [{
                 "browserName": "MicrosoftEdge",
                 "platform": "Windows 10",
+                "version": "15.15063"
+            }, {
+                "browserName": "MicrosoftEdge",
+                "platform": "Windows 10",
                 "version": "14.14393"
             }, {
                 "browserName": "safari",


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-27571
Requires: https://github.com/ezsystems/hybrid-platform-ui/pull/53

# Description

This patch adds the ability for `<ez-asynchronous-block>` (used in Content view tabs) to handle form submit and navigation happening inside the block.

So `<ez-asynchronous-block>` listens for form submit, triggers an AJAX request for it and updates itself with the server response. For links, more or less the same thing is applied but only on links having the class `ez-js-local-navigation` or descendant of an element with that class.

For this work, the server should only send the HTML code for the tabs, this is the purpose of the related PR https://github.com/ezsystems/hybrid-platform-ui/pull/53

Screencast:

[![](https://img.youtube.com/vi/I0527SXrn48/0.jpg)](http://www.youtube.com/watch?v=I0527SXrn48 "Click to play on Youtube.com")

## Tasks

* [x] extract `<ez-platform-ui-app>`/`<ez-asynchronous-block>` AJAX related code to a common mixin
* [x] form handling in tab
* [x] local to tab links (pagination, ...)

# Tests

manual test and unit tests