### PR TITLE
EZP-27563: Handle a non responding server and JSON parsing error in Hybrid Platform UI

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -33,7 +33,7 @@
             }
         ],
         "capitalized-comments": "off",
-        "class-methods-use-this": "error",
+        "class-methods-use-this": "off",
         "comma-dangle": ["error", "always-multiline"],
         "comma-spacing": [
             "error",

--- a/test/ez-platform-ui-app.html
+++ b/test/ez-platform-ui-app.html
@@ -70,6 +70,7 @@
                     </form>
                     <main>to be string updated</main>
                     <nav>to be receive an attribute update</nav>
+                    <div id="ez-notification-bar"></div>
                 </ez-platform-ui-app>
             </template>
         </test-fixture>

--- a/test/js/ez-platform-ui-app.js
+++ b/test/js/ez-platform-ui-app.js
@@ -929,7 +929,7 @@ describe('ez-platform-ui-app', function() {
                 const response = {
                     url: this.redirectUrl,
                     text: function () {
-                        return '{}';
+                        return Promise.resolve('{}');
                     },
                 };
 

--- a/test/responses/invalid.json
+++ b/test/responses/invalid.json
@@ -1,0 +1,1 @@
+invalid


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-27563
Requires https://github.com/ezsystems/hybrid-platform-ui/pull/60 (for links in notification to be readable)

# Description

This PR changes `<ez-platform-ui-app>` so that it correctly handles connection error and JSON parsing error and so that it notifies the user about that.

For JSON parsing error, the notification also carries some details that can be copied and if the server is in dev mode, it contains a link to open the Symfony Profiler (thanks @bdunogier for the suggestion).

Also, while working on that part, I took the time to refactor it as suggested by @bdunogier a while back.

**Screencast**

[![](https://img.youtube.com/vi/8II5gRNDcsU/0.jpg)](http://www.youtube.com/watch?v=8II5gRNDcsU "Click to play on Youtube.com")


# Tests

manual test + unit test