### PR TITLE
EZP-27573: Add a confirm mechanism

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,8 @@
   "name": "hybrid-platform-ui-core-components",
   "main": "core-components.html",
   "dependencies": {
-    "polymer": "^2.0.0"
+    "polymer": "^2.0.0",
+    "dialog-polyfill": "^0.4.7"
   },
   "devDependencies": {
     "iron-demo-helpers": "^2.0.0",

--- a/demo/ez-platform-ui-app.html
+++ b/demo/ez-platform-ui-app.html
@@ -15,11 +15,11 @@
     <link rel="import" href="../ez-platform-ui-app.html">
 
     <style is="custom-style" include="demo-pages-shared-styles">
-        ez-platform-ui-app {
+        .navigation {
             position: relative;
         }
 
-        ez-platform-ui-app:after {
+        .navigation:after {
             font-style: italic;
             position: absolute;
             right: 0;
@@ -34,10 +34,10 @@
   </head>
   <body>
     <div class="vertical-section-container centered">
-      <h3>Basic ez-platform-ui-app demo</h3>
+      <h3>Enhanced navigation demo</h3>
       <demo-snippet>
         <template>
-            <ez-platform-ui-app>
+            <ez-platform-ui-app class="navigation">
                 <nav data-last-update="none">
                     Navigation
                 </nav>
@@ -55,6 +55,20 @@
                 </main>
             </ez-platform-ui-app>
         </template>
+      </demo-snippet>
+      <h3>Modal demo</h3>
+      <demo-snippet>
+          <template>
+              <ez-platform-ui-app>
+                  <button type="button" value="#modal" class="ez-js-open-modal">Open</button>
+
+                  <dialog id="modal" class="ez-modal">
+                      <p>This is a modal</p>
+
+                      <button type="button" class="ez-js-close-modal">Close</button>
+                  </dialog>
+              </ez-platform-ui-app>
+          </template>
       </demo-snippet>
     </div>
   </body>

--- a/ez-platform-ui-app.html
+++ b/ez-platform-ui-app.html
@@ -1,5 +1,6 @@
 <link rel="import" href="../polymer/polymer-element.html">
 <link rel="import" href="mixins/ez-ajax-fetcher.html">
+<link rel="import" href="mixins/ez-modal.html">
 <link rel="import" href="ez-notification.html">
 
 <style>

--- a/js/ez-platform-ui-app.js
+++ b/js/ez-platform-ui-app.js
@@ -29,6 +29,8 @@
         return updateStruct;
     }
 
+    const Base = eZ.mixins.Modal(eZ.mixins.AjaxFetcher(Polymer.Element));
+
     /**
      * `<ez-platform-ui-app>` represents the application in a page which will
      * enhance the navigation by avoiding full page refresh. It is responsible
@@ -76,7 +78,7 @@
      * @polymerElement
      * @demo demo/ez-platform-ui-app.html
      */
-    class PlatformUiApp extends eZ.mixins.AjaxFetcher(Polymer.Element) {
+    class PlatformUiApp extends Base {
         static get is() {
             return 'ez-platform-ui-app';
         }

--- a/mixins/ez-modal.html
+++ b/mixins/ez-modal.html
@@ -1,0 +1,25 @@
+<link rel="stylesheet" href="../../dialog-polyfill/dialog-polyfill.css">
+<style>
+.ez-modal {
+    transform: scale(0);
+    transition: all ease 0.3s;
+}
+
+.ez-modal.is-modal-open {
+    transform: scale(1);
+}
+
+.ez-modal::backdrop,
+.ez-modal + .backdrop /* <dialog> polyfill */ {
+    opacity: 0;
+    transition: opacity ease 0.3s;
+}
+
+.ez-modal.is-modal-open::backdrop,
+.ez-modal.is-modal-open + .backdrop /* <dialog> polyfill */ {
+    opacity: 1;
+}
+
+</style>
+<script src="../../dialog-polyfill/dialog-polyfill.js"></script>
+<script src="js/ez-modal.js"></script>

--- a/mixins/js/ez-modal.js
+++ b/mixins/js/ez-modal.js
@@ -1,0 +1,92 @@
+window.eZ = window.eZ || {};
+
+/* global dialogPolyfill */
+(function (ns) {
+    ns.mixins = ns.mixins || {};
+
+    /**
+     * Mixins modal dialog support into a class extending `superClass`. The
+     * resulting class is able to display a `<dialog>` element as a modal when
+     * it contains the following markup:
+     *
+     * ```
+     * <dialog class="ez-modal" id="mymodal">
+     *   <p>Hello world!</p>
+     *   <button type="button" class="ez-js-close-modal">Close modal</button>
+     * </dialog>
+     * <button type="button" class="ez-js-open-modal" value="#mymodal">Open 'mymodal'</button>
+     * ```
+     *
+     * When clicking on a button with the class `ez-js-open-modal`, the
+     * `<dialog>` element selected by the selector in the button value attribute
+     * is opened as a modal (with `showModal` method) and the `<dialog>` receive
+     * the class `is-modal-open` so that the opening is done with a CSS
+     * transition. Clicking on any element with the class `ez-js-open-modal` in
+     * the `<dialog>` element will close the modal and remove the class
+     * `is-modal-open`.
+     *
+     * This mixin relies on the support for the `<dialog>` element which is only
+     * supported by Chrome so this mixin automatically load a Polyfill to bring
+     * this feature in others browsers.
+     *
+     * Among others standard APIs, this component relies on `Element.closest`.
+     * `Element.closest` is not available in Edge 14. So for this component to
+     * work in this browser, the page should include a polyfill for this
+     * standard API.
+     *
+     * @param {Function} superClass
+     * @return {Function}
+     */
+    ns.mixins.Modal = function (superClass) {
+        const MODAL_OPEN = 'is-modal-open';
+
+        return class extends superClass {
+            connectedCallback() {
+                super.connectedCallback();
+                this._setupModal();
+            }
+
+            /**
+             * Setups click listeners to open or close the modal window.
+             */
+            _setupModal() {
+                this.addEventListener('click', (e) => {
+                    if ( e.target.matches('.ez-js-open-modal') ) {
+                        this._openModal(e.target.value);
+                    } else if ( e.target.matches('.ez-js-close-modal') ) {
+                        this._closeModal(e.target.closest('dialog'));
+                    }
+                });
+            }
+
+            /**
+             * Opens the dialog element selected by `selector` as a modal.
+             *
+             * @param {String} selector
+             */
+            _openModal(selector) {
+                const dialog = this.querySelector(selector);
+
+                dialogPolyfill.registerDialog(dialog);
+                dialog.showModal();
+                dialog.classList.add(MODAL_OPEN);
+            }
+
+            /**
+             * Closes the dialog element.
+             *
+             * @param {HTMLDialogElement} dialog
+             */
+            _closeModal(dialog) {
+                const close = function () {
+                    dialog.removeEventListener('transitionend', close);
+                    dialog.close();
+                };
+
+                dialog.addEventListener('transitionend', close);
+                dialog.classList.remove(MODAL_OPEN);
+            }
+        };
+    };
+
+})(window.eZ);

--- a/test/ez-platform-ui-app.html
+++ b/test/ez-platform-ui-app.html
@@ -83,6 +83,21 @@
             </template>
         </test-fixture>
 
+       <test-fixture id="ModalTestFixture">
+            <template>
+                <ez-platform-ui-app>
+                    <button type="button" value="#modal" class="ez-js-open-modal">Open</button>
+
+                    <dialog id="modal" class="ez-modal">
+                        <p>This is a modal</p>
+
+                        <button type="button" class="ez-js-close-modal">Close</button>
+                    </dialog>
+                </ez-platform-ui-app>
+            </template>
+        </test-fixture>
+
         <script src="js/ez-platform-ui-app.js"></script>
+        <script src="mixins/js/ez-modal.js"></script>
     </body>
 </html>

--- a/test/mixins/ez-modal.html
+++ b/test/mixins/ez-modal.html
@@ -1,0 +1,44 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
+
+        <title>ez-modal test</title>
+
+        <script src="../../../webcomponentsjs/webcomponents-lite.js"></script>
+        <script src="../../../element-matches/closest.js"></script><!-- for Edge 14 -->
+        <script src="../../../web-component-tester/browser.js"></script>
+
+        <link rel="import" href="../../../polymer/polymer-element.html">
+        <link rel="import" href="../../mixins/ez-modal.html">
+        <script>
+        window.addEventListener('WebComponentsReady', function () {
+            class TestElement extends eZ.mixins.Modal(Polymer.Element) {
+                static get is() {
+                    return 'ez-test-modal';
+                }
+            }
+
+            window.customElements.define(TestElement.is, TestElement);
+        });
+        </script>
+    </head>
+    <body>
+        <test-fixture id="ModalTestFixture">
+            <template>
+                <ez-test-modal>
+                    <button type="button" value="#modal" class="ez-js-open-modal">Open</button>
+
+                    <dialog id="modal" class="ez-modal">
+                        <p>This is a modal</p>
+
+                        <button type="button" class="ez-js-close-modal">Close</button>
+                    </dialog>
+                </ez-test-modal>
+            </template>
+        </test-fixture>
+
+        <script src="js/ez-modal.js"></script>
+    </body>
+</html>

--- a/test/mixins/js/ez-modal.js
+++ b/test/mixins/js/ez-modal.js
@@ -1,0 +1,73 @@
+describe('ez-modal', function () {
+    let element;
+
+    beforeEach(function () {
+        element = fixture('ModalTestFixture');
+    });
+
+    it('should define `eZ.mixins.Modal`', function () {
+        assert.isFunction(window.eZ.mixins.Modal);
+    });
+
+    describe('modal', function () {
+        function simulateClick(el) {
+            el.dispatchEvent(new CustomEvent('click', {
+                bubbles: true,
+            }));
+        }
+
+        function addEventListenerOnce(element, eventName, listener) {
+            const func = function () {
+                element.removeEventListener(eventName, func);
+                listener.apply(this, arguments);
+            };
+
+            element.addEventListener(eventName, func);
+        }
+
+        describe('opening', function () {
+            it('should be opened', function (done) {
+                const modal = element.querySelector('.ez-modal');
+                const assertOpenWithTransition = function (e) {
+                    assert.strictEqual(
+                        modal, e.target,
+                        'The transition should occur on the dialog itself'
+                    );
+                    assert.isTrue(
+                        modal.classList.contains('is-modal-open'),
+                        'The dialog should have the `is-modal-open` class'
+                    );
+                    assert.isTrue(modal.open);
+                    done();
+                };
+
+                simulateClick(element.querySelector('[value="#modal"]'));
+                addEventListenerOnce(modal, 'transitionend', assertOpenWithTransition);
+            });
+        });
+
+        describe('hiding', function () {
+            it('should be hidden', function (done) {
+                const modal = element.querySelector('.ez-modal');
+
+                addEventListenerOnce(modal, 'transitionend', function () {
+                    simulateClick(modal.querySelector('button'));
+                    addEventListenerOnce(modal, 'transitionend', function (e) {
+                        assert.strictEqual(
+                            modal, e.target,
+                            'The transition should occur on the dialog itself'
+                        );
+                        assert.isFalse(
+                            modal.classList.contains('is-modal-open'),
+                            'The dialog should not have the `is-modal-open` class'
+                        );
+                        assert.isFalse(modal.open);
+                        done();
+                    });
+                });
+
+                simulateClick(element.querySelector('[value="#modal"]'));
+            });
+        });
+    });
+});


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-27573

# Description

This patch adds the `Modal` mixin. When this mixin is applied to a custom element, this element recognizes when a button is attached to a `<dialog>` element. So when clicking on such button, the `<dialog>` element is shown as a modal window.

This mixin uses the [dialog polyfill provided by Google Chrome](https://github.com/GoogleChrome/dialog-polyfill) so that the `<dialog>` is recognized by others browser.

See https://github.com/ezsystems/hybrid-platform-ui/pull/85 for a screencast.

# Test

unit test + manual tests in https://github.com/ezsystems/hybrid-platform-ui/pull/85 and https://github.com/ezsystems/PlatformUIBundle/pull/885