### PR TITLE
EZP-27582: Finished partial update of tab requests

### DIFF
--- a/js/ez-asynchronous-block.js
+++ b/js/ez-asynchronous-block.js
@@ -1,17 +1,5 @@
 /* global eZ */
 (function () {
-    // FIXME: after https://jira.ez.no/browse/EZP-27582
-    // remove that function!
-    function filterTabHTMLCode(htmlCode) {
-        const doc = (new DOMParser()).parseFromString(htmlCode, 'text/html');
-        const main = doc.querySelector('main');
-
-        if ( main ) {
-            return main.innerHTML;
-        }
-        return htmlCode;
-    }
-
     /**
      * `<ez-asynchronous-block>` represents a block that can be loaded
      * asynchronously. It exposes a `load()` method that will request its `url`.
@@ -118,7 +106,7 @@
             // FIXME: after https://jira.ez.no/browse/EZP-27582
             // this._fetch should have a second parameter with the header
             // so the server generates the HTML without the app layout
-            this._fetch(update)
+            this._fetch(update, {'Accept': 'application/partial-update+html'})
                 .then((response) => {
                     if ( response.status >= 400 ) {
                         throw new Error();
@@ -128,13 +116,7 @@
                 .then((response) => response.text())
                 .then((htmlCode) => {
                     this.loading = false;
-                    // FIXME: after https://jira.ez.no/browse/EZP-27582
-                    // this is a workaround needed because the returned tab code
-                    // is decorated with the App Layout.
-                    // when EZP-27582 is implemented, the following line should
-                    // be:
-                    // this.innerHTML = htmlCode;
-                    this.innerHTML = filterTabHTMLCode(htmlCode);
+                    this.innerHTML = htmlCode;
                     this.loaded = true;
                     this._dispatchUpdated();
                 })

--- a/js/ez-asynchronous-block.js
+++ b/js/ez-asynchronous-block.js
@@ -103,9 +103,6 @@
             const update = source || this.url;
 
             this.loading = true;
-            // FIXME: after https://jira.ez.no/browse/EZP-27582
-            // this._fetch should have a second parameter with the header
-            // so the server generates the HTML without the app layout
             this._fetch(update, {'Accept': 'application/partial-update+html'})
                 .then((response) => {
                     if ( response.status >= 400 ) {

--- a/test/js/ez-asynchronous-block.js
+++ b/test/js/ez-asynchronous-block.js
@@ -66,9 +66,16 @@ describe('ez-asynchronous-block', function() {
 
         it('should request the `url`', function () {
             element.load();
+            const headers = fetch.firstCall.args[1].headers;
 
             assert.isTrue(fetch.calledOnce);
             assert.isTrue(fetch.alwaysCalledWith(element.url));
+
+            assert.equal(
+                'application/partial-update+html',
+                headers.get('Accept'),
+                'The Accept header should be set to get a partial HTML update'
+            );
         });
 
         it('should update the content', function (done) {


### PR DESCRIPTION
> Part of [EZP-27582](http://jira.ez.no/browse/EZP-27582)
> Depends on https://github.com/ezsystems/hybrid-platform-ui/pull/64

Adds the `Accept: application/partial-update+html` header to tab updates requests.
Removes the workaround that was stripping the extra HTML due to the lack of partial update.

### TODO
- [x] Fix tests. Guidance appreciated.