### PR TITLE
Spiked an ez-select-location component

### DIFF
--- a/core-components.html
+++ b/core-components.html
@@ -7,3 +7,4 @@
 <link rel="import" href="ez-content-view.html">
 <link rel="import" href="ez-asynchronous-block.html">
 <link rel="import" href="ez-field-edit.html">
+<link rel="import" href="ez-select-location.html">

--- a/demo/ez-select-location.html
+++ b/demo/ez-select-location.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
+
+    <title>ez-select-location demo</title>
+
+    <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+
+    <link rel="import" href="../../iron-demo-helpers/demo-pages-shared-styles.html">
+    <link rel="import" href="../../iron-demo-helpers/demo-snippet.html">
+    <link rel="import" href="../ez-select-location.html">
+
+  </head>
+    <body>
+        <div class="vertical-section-container centered">
+            <h3>Basic ez-select-location demo</h3>
+            <demo-snippet>
+              <template>
+                  <ez-select-location selected-location-id="2">
+                      Select location
+                  </ez-select-location>
+                  <div id="log"></div>
+                  <script>
+                        document.addEventListener('ez:contentDiscover', (e) => {
+                            const log = document.getElementById('log');
+
+                            log.innerHTML += `<p> Selected location id is: "${e.detail.config.startingLocationId}", Title is: "${e.detail.config.title}", Confirm label is: "${e.detail.config.confirmLabel}" </p>`;
+                        });
+                  </script>
+              </template>
+            </demo-snippet>
+        </div>
+    </body>
+</html>

--- a/demo/index.html
+++ b/demo/index.html
@@ -17,6 +17,7 @@
         <li><a href="ez-content-view.html">ez-content-view</a></li>
         <li><a href="ez-asynchronous-block.html">ez-asynchronous-block</a></li>
         <li><a href="ez-field-edit.html">ez-field-edit</a></li>
+        <li><a href="ez-select-location.html">ez-select-location</a></li>
     </ul>
   </body>
 </html>

--- a/ez-select-location.html
+++ b/ez-select-location.html
@@ -1,0 +1,9 @@
+<link rel="import" href="../polymer/polymer-element.html">
+
+<style>
+ez-select-location {
+    display: block;
+    cursor: pointer;
+}
+</style>
+<script src="js/ez-select-location.js"></script>

--- a/js/ez-select-location.js
+++ b/js/ez-select-location.js
@@ -1,0 +1,70 @@
+(function () {
+    /**
+     * <ez-select-location> represents a clickable element in the application which will fire
+     * the `ez:contentDiscover` event on click. This event is responsible for launching
+     * the universal discovery widget component.
+     *
+     * @polymerElement
+     * @demo demo/ez-select-location.html
+     */
+    class SelectLocation extends Polymer.Element {
+        static get is() {
+            return 'ez-select-location';
+        }
+
+        static get properties() {
+            return {
+              /**
+               * The selected location id which will determine the starting location id of the UDW.
+               */
+                'selectedLocationId': {
+                    type: Number,
+                },
+            };
+        }
+
+        constructor() {
+            super();
+            this.addEventListener('click', this._discoverContent.bind(this));
+        }
+
+        /**
+         * Dispatches `ez:contentDiscover` event with config and listeners
+         */
+        _discoverContent() {
+            const event = new CustomEvent('ez:contentDiscover', {
+                detail: {
+                    config: {
+                        // Should be translatable in the future: https://jira.ez.no/browse/EZP-27527
+                        title: 'Select location for swapping',
+                        startingLocationId: this.selectedLocationId,
+                        confirmLabel: 'Select this location',
+                    },
+                    listeners: {
+                        'ez:confirm': (e) => {
+                            this._locationSelected(e.detail.selection.location);
+                        },
+                    },
+                },
+                bubbles: true,
+            });
+
+            this.dispatchEvent(event);
+        }
+
+        /**
+         * Dispatches `ez:locationSelected` event with the url given in the location.
+         * @param {Object} location
+         */
+        _locationSelected(location) {
+            const event = new CustomEvent('ez:locationSelected', {
+                detail: {locationId: location.id},
+                bubbles: true,
+            });
+
+            this.dispatchEvent(event);
+        }
+    }
+
+    customElements.define(SelectLocation.is, SelectLocation);
+})();

--- a/js/ez-select-location.js
+++ b/js/ez-select-location.js
@@ -36,7 +36,7 @@
                 detail: {
                     config: {
                         // Should be translatable in the future: https://jira.ez.no/browse/EZP-27527
-                        title: 'Select location for swapping',
+                        title: 'Select a location',
                         startingLocationId: this.selectedLocationId,
                         confirmLabel: 'Select this location',
                     },

--- a/test/ez-select-location.html
+++ b/test/ez-select-location.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
+
+        <title>ez-browse test</title>
+
+        <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+        <script src="../../web-component-tester/browser.js"></script>
+
+        <link rel="import" href="../ez-select-location.html">
+    </head>
+    <body>
+
+        <test-fixture id="BasicTestFixture">
+            <template>
+                <ez-select-location selected-location-id="42">
+                </ez-select-location>
+            </template>
+        </test-fixture>
+
+        <script src="js/ez-select-location.js"></script>
+    </body>
+</html>

--- a/test/js/ez-select-location.js
+++ b/test/js/ez-select-location.js
@@ -1,0 +1,87 @@
+describe('ez-select-location', function() {
+    let element;
+
+    beforeEach(function () {
+        element = fixture('BasicTestFixture');
+    });
+
+    function simulateClick(element) {
+        const click = new CustomEvent('click', {
+            bubbles: true,
+            cancelable: true,
+        });
+
+        element.dispatchEvent(click);
+        return click;
+    }
+
+    it('should be defined', function () {
+        assert.equal(
+            window.customElements.get('ez-select-location'),
+            element.constructor
+        );
+    });
+
+    describe('properties', function () {
+        describe('`selectedLocationId`', function () {
+            it('should be set by the attribute', function () {
+                assert.strictEqual(element.selectedLocationId, 42);
+            });
+        });
+    });
+
+    describe('click', function () {
+        describe('`ez:contentDiscover` event', function () {
+            it('should be dispatched', function () {
+                let eventDispatched = false;
+
+                element.addEventListener('ez:contentDiscover', (e) => {
+                    eventDispatched =  true;
+                    assert.equal(e.detail.config.title, 'Select a location', 'A title should be provided');
+                    assert.equal(e.detail.config.startingLocationId, element.selectedLocationId, 'A startingLocationId should be provided');
+                    assert.equal(e.detail.config.confirmLabel, 'Select this location', 'A confirmLabel should be provided');
+                    assert.isFunction(e.detail.listeners['ez:confirm'], 'An `ez:confirm` event listener should be provided');
+                });
+                simulateClick(element);
+                assert.isTrue(eventDispatched, 'the `ez:contentDiscover` event should be dispatched');
+            });
+
+            it('should bubble', function () {
+                let eventDispatched = false;
+
+                document.addEventListener('ez:contentDiscover', () => {
+                    eventDispatched =  true;
+                });
+                simulateClick(element);
+                assert.isTrue(eventDispatched);
+            });
+        });
+    });
+
+    describe('`ez:confirm` listener', function () {
+        it('should dispatch `ez:locationSelected` event', function () {
+            const id = 42;
+            const confirmFakeEventFacade = {
+                detail: {
+                    selection: {
+                        location: {
+                            id: id,
+                        },
+                    },
+                },
+            };
+            let eventDispatched = false;
+
+            element.addEventListener('ez:contentDiscover', (e) => {
+                e.detail.listeners['ez:confirm'](confirmFakeEventFacade);
+            });
+
+            element.addEventListener('ez:locationSelected', (e) => {
+                eventDispatched =  true;
+                assert.equal(e.detail.locationId, id, 'The location id should be provided');
+            });
+            simulateClick(element);
+            assert.isTrue(eventDispatched, 'the `locationSelected` event should be dispatched');
+        });
+    });
+});


### PR DESCRIPTION
Based on `ez-browse`, it is used to select one (or potentially more) locations.
It fires an `ez:locationSelected` event with the `locationId` on `ez:confirm`.