### PR TITLE
EZP-27657: Convention to run the UD

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ before_script:
   - bower install
 
 addons:
-  firefox: latest
+  firefox: latest-beta
   apt:
     sources:
       - google-chrome

--- a/ez-platform-ui-app.html
+++ b/ez-platform-ui-app.html
@@ -1,6 +1,7 @@
 <link rel="import" href="../polymer/polymer-element.html">
 <link rel="import" href="mixins/ez-ajax-fetcher.html">
 <link rel="import" href="mixins/ez-modal.html">
+<link rel="import" href="mixins/ez-run-universal-discovery.html">
 <link rel="import" href="ez-notification.html">
 
 <style>

--- a/js/ez-platform-ui-app.js
+++ b/js/ez-platform-ui-app.js
@@ -29,7 +29,7 @@
         return updateStruct;
     }
 
-    const Base = eZ.mixins.Modal(eZ.mixins.AjaxFetcher(Polymer.Element));
+    const {Modal, AjaxFetcher, RunUniversalDiscovery} = eZ.mixins;
 
     /**
      * `<ez-platform-ui-app>` represents the application in a page which will
@@ -69,6 +69,10 @@
      * </div>
      * ```
      *
+     * It is also created with `eZ.mixins.RunUniversalDiscovery` and
+     * `eZ.mixins.Modal` mixins, so the app is also able to recognize the markup
+     * conventions defined in those.
+     *
      * Among others standard APIs, this component relies on `fetch` and
      * `Element.closest`. `fetch` is not supported by Safari 10.0 and
      * `Element.closest` is not available in Edge 14. So for this component to
@@ -78,7 +82,7 @@
      * @polymerElement
      * @demo demo/ez-platform-ui-app.html
      */
-    class PlatformUiApp extends Base {
+    class PlatformUiApp extends AjaxFetcher(RunUniversalDiscovery(Modal(Polymer.Element))) {
         static get is() {
             return 'ez-platform-ui-app';
         }

--- a/mixins/ez-run-universal-discovery.html
+++ b/mixins/ez-run-universal-discovery.html
@@ -1,0 +1,1 @@
+<script src="js/ez-run-universal-discovery.js"></script>

--- a/mixins/js/ez-ajax-fetcher.js
+++ b/mixins/js/ez-ajax-fetcher.js
@@ -79,7 +79,7 @@ window.eZ = window.eZ || {};
              * @return {Boolean}
              */
             static _isSubmitButton(element) {
-                return element && element.matches('form input[type="submit"], form button, form input[type="image"]');
+                return element.form && (element.type === 'submit' || element.type === 'image');
             }
         };
     };

--- a/mixins/js/ez-run-universal-discovery.js
+++ b/mixins/js/ez-run-universal-discovery.js
@@ -44,6 +44,8 @@ window.eZ = window.eZ || {};
      * button in the Universal Discovery
      * * `data-ud-min-discover-depth` can be used to set the min discover depth
      * of the Universal Discovery
+     * * `data-ud-visible-method` can be used to set the default visible method
+     * in the Universal Discovery
      * * `data-ud-container` when this boolean attribute is set, the Universal
      * Discovery will be configured to only allow container Content item to be
      * selected.
@@ -146,6 +148,7 @@ window.eZ = window.eZ || {};
                     'startingLocationId': dataset.udStartingLocationId,
                     'confirmLabel': dataset.udConfirmLabel,
                     'minDiscoverDepth': dataset.udMinDiscoverDepth,
+                    'visibleMethod': dataset.udVisibleMethod,
                 };
             }
 

--- a/mixins/js/ez-run-universal-discovery.js
+++ b/mixins/js/ez-run-universal-discovery.js
@@ -38,6 +38,8 @@ window.eZ = window.eZ || {};
      * * `data-ud-multiple` when this boolean attribute is set, the Universal
      * Discovery is run the `multiple` option set to true
      * * `data-ud-title` can be used to set the title of the Universal Discovery
+     * * `data-ud-starting-location-id` can be used to set the starting Location
+     * of the Universal Discovery
      * * `data-ud-container` when this boolean attribute is set, the Universal
      * Discovery will be configured to only allow container Content item to be
      * selected.
@@ -75,6 +77,7 @@ window.eZ = window.eZ || {};
      * <button type="submit" class="ez-js-run-universal-discovery"
      *     data-ud-multiple
      *     data-ud-title="Title of the UDW"
+     *     data-ud-starting-location-id="43"
      *     data-ud-container
      *     data-ud-content-type-identifiers="folder article"
      *     data-ud-confirm-fill=".selector-of-input-to-fill"
@@ -84,8 +87,9 @@ window.eZ = window.eZ || {};
      * ```
      *
      * With that example, the Universal Discovery will allow a multiple
-     * selection of folder and articles. After confirming the selection, the
-     * input matching `.selector-of-input-to-fill` will be filled with the
+     * selection of folder and articles. It will be configured to start the
+     * discovery at the Location which id is 43. After confirming the selection,
+     * the input matching `.selector-of-input-to-fill` will be filled with the
      * Location ids and the form in which the button is will be submitted.
      *
      * @param {Function} superClass
@@ -133,7 +137,7 @@ window.eZ = window.eZ || {};
                 return {
                     'multiple': !!runUDElement.dataset.udMultiple,
                     'title': runUDElement.dataset.udTitle,
-                    // TODO read others data attributes to fully configure
+                    'startingLocationId': runUDElement.dataset.udStartingLocationId,
                 };
             }
 

--- a/mixins/js/ez-run-universal-discovery.js
+++ b/mixins/js/ez-run-universal-discovery.js
@@ -40,6 +40,8 @@ window.eZ = window.eZ || {};
      * * `data-ud-title` can be used to set the title of the Universal Discovery
      * * `data-ud-starting-location-id` can be used to set the starting Location
      * of the Universal Discovery
+     * * `data-ud-confirm-label` can be used to set the label of the confirm
+     * button in the Universal Discovery
      * * `data-ud-container` when this boolean attribute is set, the Universal
      * Discovery will be configured to only allow container Content item to be
      * selected.
@@ -134,10 +136,13 @@ window.eZ = window.eZ || {};
              * @return {Object}
              */
             _getUDConfig(runUDElement) {
+                const dataset = runUDElement.dataset;
+
                 return {
-                    'multiple': !!runUDElement.dataset.udMultiple,
-                    'title': runUDElement.dataset.udTitle,
-                    'startingLocationId': runUDElement.dataset.udStartingLocationId,
+                    'multiple': !!dataset.udMultiple,
+                    'title': dataset.udTitle,
+                    'startingLocationId': dataset.udStartingLocationId,
+                    'confirmLabel': dataset.udConfirmLabel,
                 };
             }
 

--- a/mixins/js/ez-run-universal-discovery.js
+++ b/mixins/js/ez-run-universal-discovery.js
@@ -36,7 +36,7 @@ window.eZ = window.eZ || {};
      * configured based on `data-ud-*` attributes on the button itself:
      *
      * * `data-ud-multiple` when this boolean attribute is set, the Universal
-     * Discovery is run the `multiple` option set to true
+     * Discovery is run with the `multiple` option set to true
      * * `data-ud-title` can be used to set the title of the Universal Discovery
      * * `data-ud-starting-location-id` can be used to set the starting Location
      * of the Universal Discovery
@@ -49,18 +49,18 @@ window.eZ = window.eZ || {};
      * * `data-ud-container` when this boolean attribute is set, the Universal
      * Discovery will be configured to only allow container Content item to be
      * selected.
-     * * `data-ud-content-type-identifier` expect a space separated list of
+     * * `data-ud-content-type-identifiers` expects a space separated list of
      * Content Type identifiers. When set, only Content items of the given list
      * of Content Types can be selected.
      * * `data-ud-confirm-fill` and `data-ud-confirm-fill-with` can be used to
      * fill a form input with a property of the selection.
      * `data-ud-confirm-fill` expects a selector matching an input.
-     * `data-ud-confirm-fill-with` expects a path in the selection. For
-     * instance, to retrieve the Location id(s), it should be filled with
-     * `location.id`. If the Universal Discovery is configured to allow a
-     * multiple selection, the input will be filled with the corresponding value
-     * separated by a coma (e.g. `42,43` if the user picked the Locations #42
-     * and #43)
+     * `data-ud-confirm-fill-with` expects a string representing a path to a
+     * property in the selection. For instance, to retrieve the Location id(s),
+     * it should have the valueh `location.id`. If the Universal Discovery is
+     * configured to allow a multiple selection, the input will be filled with
+     * the corresponding value separated by a coma (e.g. `42,43` if the user
+     * picked the Locations #42 and #43)
      *
      * When the Universal Discovery is run with that convention, the
      * `ez:runUniversalDiscovery:select` event is dispatched from the element

--- a/mixins/js/ez-run-universal-discovery.js
+++ b/mixins/js/ez-run-universal-discovery.js
@@ -1,0 +1,297 @@
+window.eZ = window.eZ || {};
+
+(function (ns) {
+    ns.mixins = ns.mixins || {};
+
+    /**
+     * Returns a function that first calls `prependFunc` and then `func`
+     *
+     * @param {Function} prependFunc
+     * @param {Function} func
+     * @return {Function}
+     */
+    function prependFunction(prependFunc, func) {
+        return function () {
+            prependFunc.apply(null, arguments);
+            func.apply(null, arguments);
+        };
+    }
+
+    /**
+     * Checks whether the given `element` is a submit button ie when clicking on
+     * it the form should be submitted
+     *
+     * @param {HTMLElement} element
+     * @return {Boolean}
+     */
+    function isSubmitButton(element) {
+        return element.form && (element.type === 'submit' || element.type === 'image');
+    }
+
+    /**
+     * Mixins support for running the Universal Discovery based on a convention
+     * on any HTML element. The resulting class transforms a click on an element
+     * (typically a button) with the class `ez-js-run-universal-discovery` in a
+     * request to run the Universal Discovery. The Universal Discovery will be
+     * configured based `data-ud-*` attribute on the button itself:
+     *
+     * * `data-ud-multiple` when this boolean attribute is set, the Universal
+     * Discovery is run the `multiple` option set to true
+     * * `data-ud-title` can be used to set the title of the Universal Discovery
+     * * `data-ud-container` when this boolean attribute is set, the Universal
+     * Discovery will be configured to only allow container Content item to be
+     * selected.
+     * * `data-ud-content-type-identifier` expect a space separated list of
+     * Content Type identifiers. When set, only Content items of the given list
+     * of Content Types can be selected.
+     * * `data-ud-confirm-fill` and `data-ud-confirm-fill-with` can be used to
+     * fill a form input with a property of the selection.
+     * `data-ud-confirm-fill` expects a selector matching an input.
+     * `data-ud-confirm-fill-with` expects a path in the selection. For
+     * instance, to retrieve the Location id(s), it should be filled with
+     * `location.id`. If the Universal Discovery is configured to allow a
+     * multiple selection, the input will be filled with the corresponding value
+     * separated by a coma (e.g. `42,43` if the user picked the Locations #42
+     * and #43)
+     *
+     * After confirming the Universal Discovery selection, the event
+     * `ez:runUniversalDiscovery:confirm` is dispatched from the element holding
+     * the `ez-js-run-universal-discovery` class. This event is configured to
+     * bubble, so it's possible for instance to listen to it from the document:
+     *
+     * ```js
+     * document.addEventListener('ez:runUniversalDiscovery:confirm', function (e) {
+     *     // e.detail.selection contains the UD selection
+     * }
+     * ```
+     *
+     * If the element holding the class `ez-js-run-universal-discovery` is a
+     * submit button, after confirming the selection in the Universal Discovery,
+     * the corresponding form will be submitted.
+     *
+     * Markup example:
+     *
+     * ```
+     * <button type="submit" class="ez-js-run-universal-discovery"
+     *     data-ud-multiple
+     *     data-ud-title="Title of the UDW"
+     *     data-ud-container
+     *     data-ud-content-type-identifiers="folder article"
+     *     data-ud-confirm-fill=".selector-of-input-to-fill"
+     *     data-ud-confirm-fill-with="location.id">
+     *   Run the Universal Discovery Widget
+     * </button>
+     * ```
+     *
+     * With that example, the Universal Discovery will allow a multiple
+     * selection of folder and articles. After confirming the selection, the
+     * input matching `.selector-of-input-to-fill` will be filled with the
+     * Location ids and the form in which the button is will be submitted.
+     *
+     * @param {Function} superClass
+     * @return {Function}
+     */
+    ns.mixins.RunUniversalDiscovery = function (superClass) {
+        return class extends superClass {
+            connectedCallback() {
+                super.connectedCallback();
+                this.addEventListener('click', (e) => {
+                    const runUDElement = this._getRunUDElement(e.target);
+
+                    if ( runUDElement ) {
+                        e.preventDefault();
+                        e.stopPropagation();
+                        this._runUniversalDiscovery(runUDElement);
+                    }
+                });
+            }
+
+            /**
+             * Runs the Universal Discovery with the parameters given by
+             * `runUDElement`.
+             *
+             * @param {HTMLElement} runUDElement
+             */
+            _runUniversalDiscovery(runUDElement) {
+                runUDElement.dispatchEvent(new CustomEvent('ez:contentDiscover', {
+                    bubbles: true,
+                    detail: {
+                        config: this._getUDConfig(runUDElement),
+                        listeners: this._getUDListeners(runUDElement),
+                    },
+                }));
+            }
+
+            /**
+             * Returns the config for the Universal Discovery based on
+             * `runUDElement`
+             *
+             * @param {HTMLElement} runUDElement
+             * @return {Object}
+             */
+            _getUDConfig(runUDElement) {
+                return {
+                    'multiple': !!runUDElement.dataset.udMultiple,
+                    'title': runUDElement.dataset.udTitle,
+                    // TODO read others data attributes to fully configure
+                };
+            }
+
+            /**
+             * Returns the listeners for the Universal Discovery based on
+             * `runUDElement`
+             *
+             * @param {HTMLElement} runUDElement
+             * @return {Object}
+             */
+            _getUDListeners(runUDElement) {
+                return {
+                    'ez:select': this._getUDSelectListener(runUDElement),
+                    'ez:confirm': this._getUDConfirmListener(runUDElement),
+                };
+            }
+
+            /**
+             * Returns the confirm listener based on `runUDElement`
+             *
+             * @param {HTMLElement} runUDElement
+             * @return {Function}
+             */
+            _getUDConfirmListener(runUDElement) {
+                const dataset = runUDElement.dataset;
+                let listener = (e) => {
+                    this._dispatchConfirm(runUDElement, e.detail.selection);
+                    if ( isSubmitButton(runUDElement) ) {
+                        const form = runUDElement.form;
+
+                        this._submitForm(form);
+                    }
+                };
+
+                if ( dataset.udConfirmFill && dataset.udConfirmFillWith ) {
+                    const fillInput = (e) => {
+                        const input = this.querySelector(dataset.udConfirmFill);
+
+                        input.value = this._getSelectionValue(
+                            dataset.udMultiple,
+                            e.detail.selection,
+                            dataset.udConfirmFillWith
+                        );
+                    };
+
+                    listener = prependFunction(fillInput, listener);
+                }
+
+                return listener;
+            }
+
+            /**
+             * Dispatches the `ez:runUniversalDiscovery:confirm` event from
+             * `runUDElement`
+             *
+             * @param {HTMLElement} runUDElement
+             * @param {Object|Array} selection
+             */
+            _dispatchConfirm(runUDElement, selection) {
+                runUDElement.dispatchEvent(new CustomEvent('ez:runUniversalDiscovery:confirm', {
+                    bubbles: true,
+                    cancelable: false,
+                    detail: {
+                        selection: selection,
+                    },
+                }));
+            }
+
+            /**
+             * Returns a string representing the `selection` done with the
+             * Universal Discovery by extracting the `path` from it.
+             *
+             * @param {Boolean} multiple
+             * @param {Object|Array} selection
+             * @param {String} path (e.g. `location.id`)
+             * @return {String}
+             */
+            _getSelectionValue(multiple, selection, path) {
+                const pathArray = path.split('.');
+
+                if ( !multiple ) {
+                    selection = [selection];
+                }
+                return selection.map(function (item) {
+                    return pathArray.reduce(function (value, key) {
+                        return value[key];
+                    }, item);
+                });
+            }
+
+            /**
+             * Returns the select listener based on `runUDElement`
+             *
+             * @param {HTMLElement} runUDElement
+             * @return {Function}
+             */
+            _getUDSelectListener(runUDElement) {
+                const dataset = runUDElement.dataset;
+                let listener = function () {
+                    // TODO dispatch ez:runUniversalDiscovery:select so that it's
+                    // possible to add custom contraints
+                };
+
+                if ( dataset.udContainer ) {
+                    const restrictContainer = function (e) {
+                        if ( !e.detail.selection.contentType.isContainer ) {
+                            e.preventDefault();
+                        }
+                    };
+
+                    listener = prependFunction(restrictContainer, listener);
+                }
+                if ( dataset.udContentTypeIdentifiers ) {
+                    const restrictContentTypes = function (e) {
+                        const identifiers = dataset.udContentTypeIdentifiers;
+                        const list = identifiers.split(',').map(function (identifier) {
+                            return identifier.trim();
+                        });
+
+                        if ( !list.includes(e.detail.selection.contentType.identifier) ) {
+                            e.preventDefault();
+                        }
+                    };
+
+                    listener = prependFunction(restrictContentTypes, listener);
+                }
+
+                return listener;
+            }
+
+            /**
+             * Submits the `form` as if the user clicked on a submit button ie
+             * it dispatches the `submit` event and if it's not prevented
+             * actually submits the `form`.
+             *
+             * @param {HTMLFormElement} form
+             */
+            _submitForm(form) {
+                const notPrevented = form.dispatchEvent(new CustomEvent('submit', {
+                    bubbles: true,
+                    cancelable: true,
+                }));
+
+                if ( notPrevented ) {
+                    form.submit();
+                }
+            }
+
+            /**
+             * Get the closest element with the `ez-js-run-universal-discovery`
+             * class if any.
+             *
+             * @param {HTMLElement} element
+             * @return {HTMLElement|null}
+             */
+            _getRunUDElement(element) {
+                return element.closest('.ez-js-run-universal-discovery');
+            }
+        };
+    };
+})(window.eZ);

--- a/mixins/js/ez-run-universal-discovery.js
+++ b/mixins/js/ez-run-universal-discovery.js
@@ -42,6 +42,8 @@ window.eZ = window.eZ || {};
      * of the Universal Discovery
      * * `data-ud-confirm-label` can be used to set the label of the confirm
      * button in the Universal Discovery
+     * * `data-ud-min-discover-depth` can be used to set the min discover depth
+     * of the Universal Discovery
      * * `data-ud-container` when this boolean attribute is set, the Universal
      * Discovery will be configured to only allow container Content item to be
      * selected.
@@ -143,6 +145,7 @@ window.eZ = window.eZ || {};
                     'title': dataset.udTitle,
                     'startingLocationId': dataset.udStartingLocationId,
                     'confirmLabel': dataset.udConfirmLabel,
+                    'minDiscoverDepth': dataset.udMinDiscoverDepth,
                 };
             }
 

--- a/test/ez-platform-ui-app.html
+++ b/test/ez-platform-ui-app.html
@@ -97,7 +97,21 @@
             </template>
         </test-fixture>
 
+        <test-fixture id="RunUDTestFixture">
+            <template>
+                <ez-platform-ui-app>
+                    <form class="ez-js-standard-form">
+                        <input type="text" value="" class="input-to-fill">
+                        <button type="button" class="ez-js-run-universal-discovery no-submit">No <span>submit</span></button>
+                        <button type="submit" class="ez-js-run-universal-discovery submit">Submit</button>
+                        <button type="button" class="no-action">No action</action>
+                    </form>
+                </ez-platform-ui-app>
+            </template>
+        </test-fixture>
+
         <script src="js/ez-platform-ui-app.js"></script>
         <script src="mixins/js/ez-modal.js"></script>
+        <script src="mixins/js/ez-run-universal-discovery.js"></script>
     </body>
 </html>

--- a/test/mixins/ez-run-universal-discovery.html
+++ b/test/mixins/ez-run-universal-discovery.html
@@ -1,0 +1,43 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
+
+        <title>ez-run-universal-discovery test</title>
+
+        <script src="../../../webcomponentsjs/webcomponents-lite.js"></script>
+        <script src="../../../element-matches/closest.js"></script><!-- for Edge 14 -->
+        <script src="../../../web-component-tester/browser.js"></script>
+
+        <link rel="import" href="../../../polymer/polymer-element.html">
+        <link rel="import" href="../../mixins/ez-run-universal-discovery.html">
+        <script>
+        window.addEventListener('WebComponentsReady', function () {
+            class TestElement extends eZ.mixins.RunUniversalDiscovery(Polymer.Element) {
+                static get is() {
+                    return 'ez-test-run-universal-discovery';
+                }
+            }
+
+            window.customElements.define(TestElement.is, TestElement);
+        });
+        </script>
+    </head>
+    <body>
+        <test-fixture id="RunUDTestFixture">
+            <template>
+                <ez-test-run-universal-discovery>
+                    <form>
+                        <input type="text" value="" class="input-to-fill">
+                        <button type="button" class="ez-js-run-universal-discovery no-submit">No <span>submit</span></button>
+                        <button type="submit" class="ez-js-run-universal-discovery submit">Submit</button>
+                        <button type="button" class="no-action">No action</action>
+                    </form>
+                </ez-test-run-universal-discovery>
+            </template>
+        </test-fixture>
+
+        <script src="js/ez-run-universal-discovery.js"></script>
+    </body>
+</html>

--- a/test/mixins/js/ez-run-universal-discovery.js
+++ b/test/mixins/js/ez-run-universal-discovery.js
@@ -132,7 +132,7 @@ describe('ez-run-universal-discovery', function () {
         });
 
         describe('select listener', function () {
-            let button;
+            let button, listener;
 
             beforeEach(function () {
                 button = element.querySelector('.no-submit');
@@ -161,8 +161,6 @@ describe('ez-run-universal-discovery', function () {
             }
 
             describe('container', function () {
-                let listener;
-
                 beforeEach(function () {
                     button.setAttribute('data-ud-container', true);
                     listener = getSelectListener(button);
@@ -190,8 +188,6 @@ describe('ez-run-universal-discovery', function () {
             });
 
             describe('content types', function () {
-                let listener;
-
                 beforeEach(function () {
                     button.setAttribute(
                         'data-ud-content-type-identifiers',
@@ -234,6 +230,40 @@ describe('ez-run-universal-discovery', function () {
 
                 it('should disallow `fold`', function () {
                     testDisallowContentType('fold');
+                });
+            });
+
+            describe('`ez:runUniversalDiscovery:select`', function () {
+                let selectEvt;
+
+                beforeEach(function () {
+                    listener = getSelectListener(button);
+                    selectEvt = getSelectEvent();
+                });
+
+                it('should be dispatched', function () {
+                    let runUniversalDiscoverySelect = false;
+
+                    addEventListenerOnce(document, 'ez:runUniversalDiscovery:select', function (e) {
+                        runUniversalDiscoverySelect = true;
+
+                        assert.strictEqual(
+                            e.detail.selection, selectEvt.detail.selection,
+                            'The selection should be provided in the event detail'
+                        );
+                    });
+                    listener(selectEvt);
+
+                    assert.isTrue(runUniversalDiscoverySelect);
+                });
+
+                it('should allow to prevent the selection', function () {
+                    addEventListenerOnce(element, 'ez:runUniversalDiscovery:select', function (e) {
+                        e.preventDefault();
+                    });
+                    listener(selectEvt);
+
+                    assert.isTrue(selectEvt.defaultPrevented);
                 });
             });
         });

--- a/test/mixins/js/ez-run-universal-discovery.js
+++ b/test/mixins/js/ez-run-universal-discovery.js
@@ -121,6 +121,10 @@ describe('ez-run-universal-discovery', function () {
             it('should read the confirm label parameter', function () {
                 testUDConfig(element, button, 'data-ud-confirm-label', 'Sure?', 'confirmLabel');
             });
+
+            it('should read the min discovery depth parameter', function () {
+                testUDConfig(element, button, 'data-ud-min-discover-depth', '2', 'minDiscoverDepth');
+            });
         });
 
         describe('select listener', function () {

--- a/test/mixins/js/ez-run-universal-discovery.js
+++ b/test/mixins/js/ez-run-universal-discovery.js
@@ -113,6 +113,10 @@ describe('ez-run-universal-discovery', function () {
             it('should read title parameter', function () {
                 testUDConfig(element, button, 'data-ud-title', 'Walkin\' on the sun', 'title');
             });
+
+            it('should read the starting Location id parameter', function () {
+                testUDConfig(element, button, 'data-ud-starting-location-id', '43', 'startingLocationId');
+            });
         });
 
         describe('select listener', function () {

--- a/test/mixins/js/ez-run-universal-discovery.js
+++ b/test/mixins/js/ez-run-universal-discovery.js
@@ -125,6 +125,10 @@ describe('ez-run-universal-discovery', function () {
             it('should read the min discovery depth parameter', function () {
                 testUDConfig(element, button, 'data-ud-min-discover-depth', '2', 'minDiscoverDepth');
             });
+
+            it('should read the visible method parameter', function () {
+                testUDConfig(element, button, 'data-ud-visible-method', 'search', 'visibleMethod');
+            });
         });
 
         describe('select listener', function () {

--- a/test/mixins/js/ez-run-universal-discovery.js
+++ b/test/mixins/js/ez-run-universal-discovery.js
@@ -117,6 +117,10 @@ describe('ez-run-universal-discovery', function () {
             it('should read the starting Location id parameter', function () {
                 testUDConfig(element, button, 'data-ud-starting-location-id', '43', 'startingLocationId');
             });
+
+            it('should read the confirm label parameter', function () {
+                testUDConfig(element, button, 'data-ud-confirm-label', 'Sure?', 'confirmLabel');
+            });
         });
 
         describe('select listener', function () {

--- a/test/mixins/js/ez-run-universal-discovery.js
+++ b/test/mixins/js/ez-run-universal-discovery.js
@@ -1,0 +1,365 @@
+describe('ez-run-universal-discovery', function () {
+    it('should define `eZ.mixins.RunUniversalDiscovery`', function () {
+        assert.isFunction(window.eZ.mixins.RunUniversalDiscovery);
+    });
+
+    describe('run universal discovery', function () {
+        let element;
+
+        beforeEach(function () {
+            element = fixture('RunUDTestFixture');
+        });
+
+        function getClickEvent() {
+            return new CustomEvent('click', {
+                bubbles: true,
+                cancelable: true,
+            });
+        }
+
+        function simulateClick(element, event = getClickEvent()) {
+            element.dispatchEvent(event);
+            return event;
+        }
+
+        function addEventListenerOnce(element, event, listener) {
+            const func = function () {
+                element.removeEventListener(event, func);
+                listener.apply(element, arguments);
+            };
+
+            element.addEventListener(event, func);
+        }
+
+        describe('run universal discovery element', function () {
+            function testClickTransformedToContentDiscover(event, element, clickElement, button) {
+                let runUD = false;
+
+                sinon.spy(event, 'stopPropagation');
+                addEventListenerOnce(element, 'ez:contentDiscover', function (e) {
+                    runUD = true;
+
+                    assert.strictEqual(
+                        e.target, button,
+                        'The `ez:contentDiscover` event should come from the button'
+                    );
+                });
+
+                simulateClick(clickElement, event);
+
+                assert.isTrue(
+                    event.defaultPrevented,
+                    'The click event should have been prevented'
+                );
+                assert.isTrue(
+                    event.stopPropagation.calledOnce,
+                    'The click event propagation should have been stopped'
+                );
+                assert.isTrue(runUD);
+            }
+
+            it('should run the universal discovery', function () {
+                const button = element.querySelector('.no-submit');
+                const event = getClickEvent();
+
+                testClickTransformedToContentDiscover(event, element, button, button);
+            });
+
+            it('should run the universal discovery with a sub element', function () {
+                const button = element.querySelector('.no-submit');
+                const subElement = button.querySelector('span');
+                const event = getClickEvent();
+
+                testClickTransformedToContentDiscover(event, element, subElement, button);
+            });
+
+            it('should ignore other button', function () {
+                const button = element.querySelector('.no-action');
+                const event = simulateClick(button);
+
+                assert.isFalse(
+                    event.defaultPrevented,
+                    'The click event should not have been prevented'
+                );
+            });
+        });
+
+        describe('config', function () {
+            let button;
+
+            beforeEach(function () {
+                button = element.querySelector('.no-submit');
+            });
+
+            function testUDConfig(element, button, dataAttr, dataAttrValue, configProp) {
+                let runUD = false;
+
+                button.setAttribute(dataAttr, dataAttrValue);
+
+                addEventListenerOnce(element, 'ez:contentDiscover', function (e) {
+                    runUD = true;
+
+                    assert.strictEqual(dataAttrValue, e.detail.config[configProp]);
+                });
+                simulateClick(button);
+
+                assert.isTrue(runUD, 'The `ez:contentDiscover` should have been dispatched');
+            }
+
+            it('should read multiple parameter', function () {
+                testUDConfig(element, button, 'data-ud-multiple', true, 'multiple');
+            });
+
+            it('should read title parameter', function () {
+                testUDConfig(element, button, 'data-ud-title', 'Walkin\' on the sun', 'title');
+            });
+        });
+
+        describe('select listener', function () {
+            let button;
+
+            beforeEach(function () {
+                button = element.querySelector('.no-submit');
+            });
+
+            function getSelectListener(button) {
+                let listener;
+
+                addEventListenerOnce(button, 'ez:contentDiscover', function (e) {
+                    listener = e.detail.listeners['ez:select'];
+                });
+                simulateClick(button);
+
+                return listener;
+            }
+
+            function getSelectEvent(contentType) {
+                return new CustomEvent('ez:select', {
+                    cancelable: true,
+                    detail: {
+                        selection: {
+                            contentType: contentType,
+                        },
+                    },
+                });
+            }
+
+            describe('container', function () {
+                let listener;
+
+                beforeEach(function () {
+                    button.setAttribute('data-ud-container', true);
+                    listener = getSelectListener(button);
+                });
+
+                it('should allow container', function () {
+                    const selectContainer = getSelectEvent({isContainer: true});
+
+                    listener(selectContainer);
+                    assert.isFalse(
+                        selectContainer.defaultPrevented,
+                        'The selection of a container should not have been prevented'
+                    );
+                });
+
+                it('should disallow non container', function () {
+                    const selectNotContainer = getSelectEvent({isContainer: false});
+
+                    listener(selectNotContainer);
+                    assert.isTrue(
+                        selectNotContainer.defaultPrevented,
+                        'The selection of a non container should have been prevented'
+                    );
+                });
+            });
+
+            describe('content types', function () {
+                let listener;
+
+                beforeEach(function () {
+                    button.setAttribute(
+                        'data-ud-content-type-identifiers',
+                        'folder,    trim-applied  '
+                    );
+                    listener = getSelectListener(button);
+                });
+
+                function testAllowContentType(identifier) {
+                    const allow = getSelectEvent({identifier: identifier});
+
+                    listener(allow);
+                    assert.isFalse(
+                        allow.defaultPrevented,
+                        `The selection of '${identifier}' should not have been prevented`
+                    );
+                }
+
+                function testDisallowContentType(identifier) {
+                    const disallow = getSelectEvent({identifier: identifier});
+
+                    listener(disallow);
+                    assert.isTrue(
+                        disallow.defaultPrevented,
+                        `The selection of '${identifier}' should have been prevented`
+                    );
+                }
+
+                it('should allow `folder`', function () {
+                    testAllowContentType('folder');
+                });
+
+                it('should disallow `article`', function () {
+                    testDisallowContentType('article');
+                });
+
+                it('should allow `trim-applied`', function () {
+                    testAllowContentType('trim-applied');
+                });
+
+                it('should disallow `fold`', function () {
+                    testDisallowContentType('fold');
+                });
+            });
+        });
+
+        describe('confirm listener', function () {
+            let button, listener;
+
+            function getConfirmListener(button) {
+                let listener;
+
+                addEventListenerOnce(button, 'ez:contentDiscover', function (e) {
+                    listener = e.detail.listeners['ez:confirm'];
+                });
+                simulateClick(button);
+
+                return listener;
+            }
+
+            function getConfirmEvent(selection) {
+                return new CustomEvent('ez:select', {
+                    cancelable: true,
+                    detail: {
+                        selection: selection,
+                    },
+                });
+            }
+
+            describe('fill', function () {
+                let input;
+
+                beforeEach(function () {
+                    const inputSelector = '.input-to-fill';
+
+                    input = element.querySelector(inputSelector);
+                    button = element.querySelector('.no-submit');
+                    button.setAttribute('data-ud-confirm-fill', inputSelector);
+                    button.setAttribute('data-ud-confirm-fill-with', 'location.id');
+                    listener = getConfirmListener(button);
+                });
+
+                it('should fill input', function () {
+                    const locationId = 42;
+                    const selection = {'location': {'id': locationId}};
+                    const confirmEvent = getConfirmEvent(selection);
+
+                    listener(confirmEvent);
+
+                    assert.equal(locationId, input.value);
+                });
+
+                it('should fill with several values', function () {
+                    const locationIds = [42, 43, 44];
+                    const selection = locationIds.map(function (locationId) {
+                        return {location: {id: locationId}};
+                    });
+
+                    button.setAttribute('data-ud-multiple', true);
+                    const confirmEvent = getConfirmEvent(selection);
+
+                    listener(confirmEvent);
+
+                    assert.equal(locationIds.toString(), input.value);
+                });
+            });
+
+            describe('form', function () {
+                let form;
+
+                beforeEach(function () {
+                    form = element.querySelector('form');
+                    sinon.stub(form, 'submit');
+                });
+
+                it('should not submit the form', function () {
+                    let submit = false;
+                    const button = element.querySelector('.no-submit');
+
+                    listener = getConfirmListener(button);
+
+                    addEventListenerOnce(form, 'submit', function () {
+                        submit = true;
+                    });
+                    listener(getConfirmEvent({}));
+
+                    assert.isFalse(submit);
+                    assert.isFalse(form.submit.called);
+                });
+
+                it('should dispatch the submit event', function () {
+                    let submit = false;
+                    const button = element.querySelector('.submit');
+
+                    listener = getConfirmListener(button);
+
+                    addEventListenerOnce(document, 'submit', function (e) {
+                        e.preventDefault();
+                        submit = true;
+                    });
+                    listener(getConfirmEvent({}));
+
+                    assert.isTrue(submit);
+                    assert.isFalse(form.submit.called);
+
+                });
+
+                it('should submit the form', function () {
+                    let submit = false;
+                    const button = element.querySelector('.submit');
+
+                    listener = getConfirmListener(button);
+
+                    addEventListenerOnce(document, 'submit', function () {
+                        submit = true;
+                    });
+                    listener(getConfirmEvent({}));
+
+                    assert.isTrue(submit);
+                    assert.isTrue(form.submit.calledOnce);
+                });
+            });
+
+            describe('`ez:runUniversalDiscovery:confirm`', function () {
+                it('should be dispatched', function () {
+                    let confirm = true;
+                    const button = element.querySelector('.no-submit');
+                    const selection = {};
+
+                    listener = getConfirmListener(button);
+
+                    addEventListenerOnce(document, 'ez:runUniversalDiscovery:confirm', function (e) {
+                        confirm = true;
+
+                        assert.strictEqual(
+                            selection, e.detail.selection,
+                            'The selection should be provided in the event parameters'
+                        );
+                    });
+                    listener(getConfirmEvent(selection));
+
+                    assert.isTrue(confirm);
+                });
+            });
+        });
+    });
+});

--- a/wct.conf.json
+++ b/wct.conf.json
@@ -17,7 +17,7 @@
             }, {
                 "browserName": "firefox",
                 "platform": "macOS 10.12",
-                "version": "latest"
+                "version": "beta"
             }, {
                 "browserName": "firefox",
                 "platform": "Windows 10",


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-27657

# Description

This patch brings a new mixin called `eZ.mixins.RunUniversalDiscovery`. This mixin is used to create the `<ez-platform-ui-app>` custom element and thanks to it, a markup convention allowing to run the universal discovery is now recognized. So with that in place the clicking on the following button will run the Universal Discovery:

```html
<button type="button" class="ez-js-run-universal-discovery"
    data-ud-title="Let's discover multiple things from /Media (43)"
    data-ud-multiple
    data-ud-starting-location-id="43"
    data-ud-content-type-identifiers="thing another-thing">
Run UD from /Media and allow multiple 'thing' and 'another-thing' Content items to be selected
</button>
```
    
## Tasks

* [x] Design the markup convention
* [x] Add a mixin to recognize the convention
* [x] Make sure to support all UDW config options
* [x] Apply the mixin to the App
* [x] Expose `select` event (will be useful in the Swap case)

# Tests

unit tests + manual test in https://github.com/ezsystems/hybrid-platform-ui/pull/87