### PR TITLE
EZP-27782: All tabs, from unrelated blocks, become unselected after clicking on any other tab

### DIFF
--- a/mixins/js/ez-tabs.js
+++ b/mixins/js/ez-tabs.js
@@ -78,7 +78,9 @@ window.eZ = window.eZ || {};
 
                     e.preventDefault();
                     if ( this._dispatchTabChange(label, panel) ) {
-                        this._changeTab(panel, label);
+                        const tabsContainer = e.target.closest('.ez-tabs');
+
+                        this._changeTab(panel, label, tabsContainer);
                     }
                 }
             }
@@ -107,9 +109,10 @@ window.eZ = window.eZ || {};
              *
              * @param {HTMLElement} panel
              * @param {HTMLElement} tabsLabel
+             * @param {HTMLElement} tabs container DOM node
              */
-            _changeTab(panel, tabsLabel) {
-                this._unselectTab();
+            _changeTab(panel, tabsLabel, tabsContainer) {
+                this._unselectTab(tabsContainer);
 
                 tabsLabel.classList.add(TAB_IS_SELECTED);
                 panel.classList.add(TAB_IS_SELECTED);
@@ -117,11 +120,13 @@ window.eZ = window.eZ || {};
 
             /**
              * Unselects currently selected tabs
+             *
+             * @param {HTMLElement} tabs container DOM node
              */
-            _unselectTab() {
+            _unselectTab(tabsContainer) {
                 const forEach = Array.prototype.forEach;
 
-                forEach.call(this.querySelectorAll('.' + TAB_IS_SELECTED), function (element) {
+                forEach.call(tabsContainer.querySelectorAll('.' + TAB_IS_SELECTED), function (element) {
                     element.classList.remove(TAB_IS_SELECTED);
                 });
             }

--- a/test/ez-content-view.html
+++ b/test/ez-content-view.html
@@ -17,20 +17,22 @@
         <test-fixture id="BasicTestFixture">
             <template>
                 <ez-content-view>
-                    <ul class="ez-tabs-list">
-                        <li class="ez-tabs-label is-tab-selected"><a href="#tab1">Tab 1</a></li>
-                        <li class="ez-tabs-label"><a href="#tab2" class="tab-link">Tab 2</a></li>
-                        <li class="ez-tabs-label"><a href="#async-tab" class="async-tab-link">Async tab</a></li>
-                    </ul>
-                    <div class="ez-tabs-panels">
-                        <div class="ez-tabs-panel is-tab-selected" id="tab1">
-                            <a href="#whatever" class="not-tabs-label">Not tabs label link</a>
-                            Some content
+                    <div class="ez-tabs">
+                        <ul class="ez-tabs-list">
+                            <li class="ez-tabs-label is-tab-selected"><a href="#tab1">Tab 1</a></li>
+                            <li class="ez-tabs-label"><a href="#tab2" class="tab-link">Tab 2</a></li>
+                            <li class="ez-tabs-label"><a href="#async-tab" class="async-tab-link">Async tab</a></li>
+                        </ul>
+                        <div class="ez-tabs-panels">
+                            <div class="ez-tabs-panel is-tab-selected" id="tab1">
+                                <a href="#whatever" class="not-tabs-label">Not tabs label link</a>
+                                Some content
+                            </div>
+                            <div class="ez-tabs-panel" id="tab2">
+                                Some other content
+                            </div>
+                            <ez-asynchronous-block id="async-tab"></ez-asynchronous-block>
                         </div>
-                        <div class="ez-tabs-panel" id="tab2">
-                            Some other content
-                        </div>
-                        <ez-asynchronous-block id="async-tab"></ez-asynchronous-block>
                     </div>
                 </ez-content-view>
             </template>

--- a/test/ez-server-side-content.html
+++ b/test/ez-server-side-content.html
@@ -17,20 +17,22 @@
         <test-fixture id="BasicTestFixture">
             <template>
                 <ez-server-side-content>
-                    <ul class="ez-tabs-list">
-                        <li class="ez-tabs-label is-tab-selected"><a href="#tab1">Tab 1</a></li>
-                        <li class="ez-tabs-label"><a href="#tab2" class="tab-link">Tab 2</a></li>
-                        <li class="ez-tabs-label"><a href="#async-tab" class="async-tab-link">Async tab</a></li>
-                    </ul>
-                    <div class="ez-tabs-panels">
-                        <div class="ez-tabs-panel is-tab-selected" id="tab1">
-                            <a href="#whatever" class="not-tabs-label">Not tabs label link</a>
-                            Some content
+                    <div class="ez-tabs">
+                        <ul class="ez-tabs-list">
+                            <li class="ez-tabs-label is-tab-selected"><a href="#tab1">Tab 1</a></li>
+                            <li class="ez-tabs-label"><a href="#tab2" class="tab-link">Tab 2</a></li>
+                            <li class="ez-tabs-label"><a href="#async-tab" class="async-tab-link">Async tab</a></li>
+                        </ul>
+                        <div class="ez-tabs-panels">
+                            <div class="ez-tabs-panel is-tab-selected" id="tab1">
+                                <a href="#whatever" class="not-tabs-label">Not tabs label link</a>
+                                Some content
+                            </div>
+                            <div class="ez-tabs-panel" id="tab2">
+                                Some other content
+                            </div>
+                            <ez-asynchronous-block id="async-tab"></ez-asynchronous-block>
                         </div>
-                        <div class="ez-tabs-panel" id="tab2">
-                            Some other content
-                        </div>
-                        <ez-asynchronous-block id="async-tab"></ez-asynchronous-block>
                     </div>
                 </ez-server-side-content>
             </template>

--- a/test/mixins/ez-tabs.html
+++ b/test/mixins/ez-tabs.html
@@ -29,17 +29,48 @@
         <test-fixture id="BasicTestFixture">
             <template>
                 <ez-test-tabs>
-                    <ul class="ez-tabs-list">
-                        <li class="ez-tabs-label is-tab-selected"><a href="#tab1">Tab 1</a></li>
-                        <li class="ez-tabs-label"><a href="#tab2" class="tab-link">Tab 2</a></li>
-                    </ul>
-                    <div class="ez-tabs-panels">
-                        <div class="ez-tabs-panel is-tab-selected" id="tab1">
-                            <a href="#whatever" class="not-tabs-label">Not tabs label link</a>
-                            Some content
+                    <div class="ez-tabs">
+                        <ul class="ez-tabs-list">
+                            <li class="ez-tabs-label is-tab-selected"><a href="#tab1">Tab 1</a></li>
+                            <li class="ez-tabs-label"><a href="#tab2" class="tab-link">Tab 2</a></li>
+                        </ul>
+                        <div class="ez-tabs-panels">
+                            <div class="ez-tabs-panel is-tab-selected" id="tab1">
+                                <a href="#whatever" class="not-tabs-label">Not tabs label link</a>
+                                Some content
+                            </div>
+                            <div class="ez-tabs-panel" id="tab2">
+                                Some other content
+                            </div>
                         </div>
-                        <div class="ez-tabs-panel" id="tab2">
-                            Some other content
+                    </div>
+                </ez-test-tabs>
+            </template>
+        </test-fixture>
+
+        <test-fixture id="AdvancedTestFixture">
+            <template>
+                <ez-test-tabs>
+                    <div class="ez-tabs">
+                        <ul class="ez-tabs-list">
+                            <li class="ez-tabs-label is-tab-selected" id="test-tab"><a href="#tab1">Tab 1</a></li>
+                            <li class="ez-tabs-label"><a href="#tab2" id="clickable-link">Tab 2</a></li>
+                        </ul>
+                        <div class="ez-tabs-panels">
+                            <div class="ez-tabs-panel is-tab-selected" id="tab1">Tab1 content</div>
+                            <div class="ez-tabs-panel" id="tab2">Tab2 content</div>
+                        </div>
+                    </div>
+                </ez-test-tabs>
+                <ez-test-tabs>
+                    <div class="ez-tabs">
+                        <ul class="ez-tabs-list">
+                            <li class="ez-tabs-label is-tab-selected"><a href="#tab3">Tab 3</a></li>
+                            <li class="ez-tabs-label"><a href="#tab4">Tab 4</a></li>
+                        </ul>
+                        <div class="ez-tabs-panels">
+                            <div class="ez-tabs-panel is-tab-selected" id="tab3">Tab3 content</div>
+                            <div class="ez-tabs-panel" id="tab4">Tab4 content</div>
                         </div>
                     </div>
                 </ez-test-tabs>

--- a/test/mixins/js/ez-tabs.js
+++ b/test/mixins/js/ez-tabs.js
@@ -1,22 +1,20 @@
 describe('ez-tabs', function () {
     let element;
 
-    beforeEach(function () {
-        element = fixture('BasicTestFixture');
-    });
-
     it('should define `eZ.mixins.Tabs`', function () {
         assert.isFunction(window.eZ.mixins.Tabs);
     });
 
-    describe('swich tab', function () {
+    function simulateClick(element) {
+        element.dispatchEvent(new CustomEvent('click', {
+            bubbles: true,
+        }));
+    }
+
+    describe('switch tab', function () {
         let link, label, panel;
 
-        function simulateClick(element) {
-            element.dispatchEvent(new CustomEvent('click', {
-                bubbles: true,
-            }));
-        }
+        element = fixture('BasicTestFixture');
 
         beforeEach(function () {
             link = element.querySelector('.tab-link');
@@ -103,6 +101,40 @@ describe('ez-tabs', function () {
                     'A new panel should not be visible'
                 );
             });
+        });
+    });
+
+    describe('switch tab in a correct container', function () {
+        let link, label, panel;
+
+        const CLASS_TAB_SELECTED = 'is-tab-selected';
+        const SELECTOR_TAB_SELECTED = '.is-tab-selected';
+
+        element = fixture('AdvancedTestFixture');
+
+        beforeEach(function () {
+            link = element.querySelector('#clickable-link');
+            label = link.parentNode;
+            panel = element.querySelector(link.getAttribute('href'));
+        });
+
+        it('should change tab in a correct tabs container', function () {
+            const tabContainers = [].slice.call(element.querySelectorAll('.ez-tabs'));
+            const selectedTabs = [].slice.call(element.querySelectorAll(SELECTOR_TAB_SELECTED));
+            const selectedTab = element.querySelector('#test-tab');
+            const selectedPanel = element.querySelector('#tab1');
+
+            simulateClick(link);
+
+            tabContainers.forEach(function (container) {
+                assert.length(container.querySelectorAll(SELECTOR_TAB_SELECTED), 1, 'The tabs container should contain one tab selected');
+            });
+
+            assert.isFalse(selectedTab.classList.contains(CLASS_TAB_SELECTED), 'Previously selected tab should be unselected');
+            assert.isFalse(selectedPanel.classList.contains(CLASS_TAB_SELECTED), 'Previously selected panel should not be visible');
+
+            assert.isTrue(label.classList.contains(CLASS_TAB_SELECTED), 'A new tab should be selected');
+            assert.isTrue(panel.classList.contains(CLASS_TAB_SELECTED), 'A new panel should be visible');
         });
     });
 });


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-27782

Now, the script is looking for the closest tabs container that contains selected tabs instead of searching in whole page document.

**The HTML markup where an issue had been spotted:**
```html
<ez-server-side-content>
    <section class="ez-tabs ez-dashboard-tabs">
        <ul class="ez-tabs-list">
            <li class="ez-tabs-label is-tab-selected"><a href="#all_content">Content</a></li>
            <li class="ez-tabs-label"><a href="#all_media">Media</a></li>
        </ul>

        <ez-asynchronous-block class="ez-tabs-panel is-tab-selected" id="all_content" url="/all_content"></ez-asynchronous-block>
        <ez-asynchronous-block class="ez-tabs-panel" id="all_media" url="/all_media"></ez-asynchronous-block>
    </section>

    <section class="ez-tabs ez-dashboard-tabs">
        <ul class="ez-tabs-list">
            <li class="ez-tabs-label is-tab-selected"><a href="#my_content">My content</a></li>
            <li class="ez-tabs-label"><a href="#my_drafts">My drafts</a></li>
            <li class="ez-tabs-label"><a href="#my_media">My media</a></li>
        </ul>

        <ez-asynchronous-block class="ez-tabs-panel is-tab-selected" id="my_content" url="/my_content"></ez-asynchronous-block>
        <ez-asynchronous-block class="ez-tabs-panel" id="my_drafts" url="/my_drafts"></ez-asynchronous-block>
        <ez-asynchronous-block class="ez-tabs-panel" id="my_media" url="/my_media"></ez-asynchronous-block>
    </section>
</ez-server-side-content>
```